### PR TITLE
[ci] allow nix to pin specific version of test case

### DIFF
--- a/.github/workflows/postpr.yml
+++ b/.github/workflows/postpr.yml
@@ -134,21 +134,21 @@ jobs:
         with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
           prerelease: true
-          automatic_release_tag: "latest"
+          automatic_release_tag: "${{ github.sha }}"
           title: "Testcase Release ${{ github.sha }}"
           files: ./rvv-testcase.tar.gz
       - if: ${{ steps.build.outputs.do_release == 'true' }}
         run: |
           . .github/scripts/ci.sh
-          bump
+          bump "$GITHUB_SHA"
       - if: ${{ steps.build.outputs.do_release == 'true' }}
         uses: peter-evans/create-pull-request@v5
         with:
           add-paths: ./nix/rvv-testcase-unwrapped.nix
-          commit-message: "[nix] bump testcase"
+          commit-message: "[nix] bump testcase to version ${{ github.sha }}"
           branch: nix-testcase-bump
           delete-branch: true
-          title: "[nix] bump testcase"
+          title: "[nix] bump testcase to version ${{ github.sha }}"
           body: "Bump rvv-testcase-unwrapped.nix"
           reviewers: |
             avimitin

--- a/nix/rvv-testcase-unwrapped.nix
+++ b/nix/rvv-testcase-unwrapped.nix
@@ -4,7 +4,7 @@ stdenv.mkDerivation rec {
   name = "rvv-testcase-unwrapped";
   version = "latest";
   src = fetchurl {
-    url = "https://github.com/sequencer/vector/releases/download/${version}/rvv-testcase.tar.gz";
+    url = "https://github.com/chipsalliance/t1/releases/download/${version}/rvv-testcase.tar.gz";
     sha256 = "sha256-Dbs22BnNaX+EEeWH+sEy4e7LIUv2pxW89cEsHW0Op2Q=";
   };
   dontUnpack = true;
@@ -12,4 +12,8 @@ stdenv.mkDerivation rec {
     mkdir $out
     tar xzf $src -C $out
   '';
+
+  # Nix provided utilities doesn't recognize this pre-built static linked ELF.
+  dontStrip = true;
+  dontPatchELF = true;
 }


### PR DESCRIPTION
This commit rewrite the release strategy to not to replace artifacts in tag 'latest`, but to upload new tag when test case changes. CI is also updated to bump version automatically when new tag is released.