### PR TITLE
[soc] move emulated axibfm to posedge

### DIFF
--- a/subsystememu/csrc/dpic.cc
+++ b/subsystememu/csrc/dpic.cc
@@ -77,7 +77,33 @@ extern "C" void AXI4BFMDPI(
     OUT svBitVecVal* bresp,
     OUT svLogic* bvalid,
     IN  svLogic bready) {
+
+    // CTRL START {
+    axi4_ref <30,32,4> ref(mem_sigs);
+    ram.beat(ref);
+    // CTRL  END  }
     
+    // output ar
+    *arready = mem_sigs.arready;
+
+    // output r
+    *rid    = mem_sigs.rid;
+    *rdata  = mem_sigs.rdata;
+    *rlast  = mem_sigs.rlast;
+    *rresp  = mem_sigs.rresp;
+    *rvalid = mem_sigs.rvalid;
+
+    // output aw
+    *awready= mem_sigs.awready;
+
+    // output w
+    *wready = mem_sigs.wready;
+
+    // output b
+    *bid    = mem_sigs.bid;
+    *bresp  = mem_sigs.bresp;
+    *bvalid = mem_sigs.bvalid;
+
     // input ar
     mem_sigs.arid   = *arid;
     mem_sigs.araddr = *araddr;
@@ -105,30 +131,4 @@ extern "C" void AXI4BFMDPI(
     
     // input b
     mem_sigs.bready = bready;
-
-    // CTRL START {
-    axi4_ref <30,32,4> ref(mem_sigs);
-    ram.beat(ref);
-    // CTRL  END  }
-    
-    // output ar
-    *arready = mem_sigs.arready;
-
-    // output r
-    *rid    = mem_sigs.rid;
-    *rdata  = mem_sigs.rdata;
-    *rlast  = mem_sigs.rlast;
-    *rresp  = mem_sigs.rresp;
-    *rvalid = mem_sigs.rvalid;
-
-    // output aw
-    *awready= mem_sigs.awready;
-
-    // output w
-    *wready = mem_sigs.wready;
-
-    // output b
-    *bid    = mem_sigs.bid;
-    *bresp  = mem_sigs.bresp;
-    *bvalid = mem_sigs.bvalid;
 }


### PR DESCRIPTION
The original AXI4BFM software side will consume AXI4 input signals from dut and generate the corresponding output at negedge, which will cause the axi4 interface to behave as combinational logic rather than sequential logic. In this case, when the master side DUT generates a ReadAddress request, it will get ReadData in the same cycle, violating the AMBA spec.

I discovered this mistake and solved it by moving the input signal update after `ram.beat`. Thus, the BFM software side will behave like a posedge model, consuming signals from the previous tick to generate the output at the current tick. As the AMBA spec does not allow any combinational logic between input and output in the AXI4 interface, we don't need to consider whether the output signal will change the input signal in the same tick.