### PR TITLE
[ci] generate shorter tag for GitHub release

### DIFF
--- a/.github/scripts/ci.sh
+++ b/.github/scripts/ci.sh
@@ -38,6 +38,7 @@ check_before_do_release() {
   else
     echo "Hash is changed from $old_hash to $new_hash, make new release"
     echo "do_release=true" >> $GITHUB_OUTPUT
+    echo "tag=$(date +%F)+$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
   fi
 }
 

--- a/.github/workflows/postpr.yml
+++ b/.github/workflows/postpr.yml
@@ -134,21 +134,21 @@ jobs:
         with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
           prerelease: true
-          automatic_release_tag: "${{ github.sha }}"
-          title: "Testcase Release ${{ github.sha }}"
+          automatic_release_tag: "${{ steps.build.outputs.tag }}"
+          title: "Testcase Release ${{ steps.build.outputs.tag }}"
           files: ./rvv-testcase.tar.gz
       - if: ${{ steps.build.outputs.do_release == 'true' }}
         run: |
           . .github/scripts/ci.sh
-          bump "$GITHUB_SHA"
+          bump "${{ steps.build.outputs.tag }}"
       - if: ${{ steps.build.outputs.do_release == 'true' }}
         uses: peter-evans/create-pull-request@v5
         with:
           add-paths: ./nix/rvv-testcase-unwrapped.nix
-          commit-message: "[nix] bump testcase to version ${{ github.sha }}"
+          commit-message: "[nix] bump testcase to version ${{ steps.build.outputs.tag }}"
           branch: nix-testcase-bump
           delete-branch: true
-          title: "[nix] bump testcase to version ${{ github.sha }}"
+          title: "[nix] bump testcase to version ${{ steps.build.outputs.tag }}"
           body: "Bump rvv-testcase-unwrapped.nix"
           reviewers: |
             avimitin


### PR DESCRIPTION
Git doesn't support tag that has more than 40 character, so it will refuse to create new tag when we use github.sha as tag.