### PR TITLE
[tests] fix testcase build environment and test strategy

### DIFF
--- a/.github/scripts/ci.sh
+++ b/.github/scripts/ci.sh
@@ -18,9 +18,16 @@ get_version() {
   nix_eval "pkg.version"
 }
 
-nix_hash() {
+nix_hash_file() {
   local filepath=$1; shift
-  nix hash file --base16 --type sha256 --sri $filepath
+  # base32 is most used encoding in Nixpkgs
+  nix hash file --base32 --type sha256 --sri $filepath
+}
+
+# nix hash path create a NAR format for the given path then hash it
+nix_hash_path() {
+  local path=$1; shift
+  nix hash path --base32 --type sha256 --sri $path
 }
 
 nix_fetch() {
@@ -28,17 +35,32 @@ nix_fetch() {
   nix-prefetch-url $url --print-path --type sha256
 }
 
+# Try to build testcase and compare it's hash to the previous release
 check_before_do_release() {
-  local artifact=$1; shift
-  local new_hash=$(nix_hash $artifact)
-  local old_hash=$(get_output_hash)
+  local output_file=$1; shift
+
+  nix build .#testcase --print-build-logs --out-link result
+  local output_dir=$(realpath ./result)
+  local new_hash=$(nix_hash_path $output_dir)
+
+  # Nix hash for tar archive changed everytime when testcase got rebuild in GitHub Action.
+  # So here I have to use nix hash path to compare only testcase elf and configs.
+  local original_file=$(nix_fetch $(get_src_url) | tail -n1)
+  local temp_dir=$(mktemp -d -t "rvv-testcase-XXX")
+  tar xzf "$original_file" -C "$temp_dir"
+  local old_hash=$(nix_hash_path $temp_dir)
+
   if [[ "$old_hash" = "$new_hash" ]]; then
     echo "Hash are still the same, no release will be made"
     echo "do_release=false" >> $GITHUB_OUTPUT
   else
     echo "Hash is changed from $old_hash to $new_hash, make new release"
+    echo "Different content: "
+    diff -bur $temp_dir $output_dir
+
     echo "do_release=true" >> $GITHUB_OUTPUT
     echo "tag=$(date +%F)+$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+    tar czf $output_file --directory $output_dir .
   fi
 }
 
@@ -62,7 +84,7 @@ bump() {
   local new_file=$(nix_fetch "$src_url" | tail -n1)
   echo "File downloaded to $new_file"
 
-  new_hash=$(nix_hash $new_file)
+  new_hash=$(nix_hash_file $new_file)
   echo "Generated new hash: $new_hash"
   old_hash=$(get_output_hash)
   sed -i "s|$old_hash|$new_hash|" $NIX_FILE

--- a/.github/workflows/postpr.yml
+++ b/.github/workflows/postpr.yml
@@ -124,8 +124,6 @@ jobs:
             sandbox = relaxed
       - id: build
         run: |
-          nix build .#testcase --print-build-logs --out-link result
-          tar czvf rvv-testcase.tar.gz --directory ./result .
           . .github/scripts/ci.sh
           check_before_do_release ./rvv-testcase.tar.gz
       - uses: "marvinpinto/action-automatic-releases@latest"

--- a/nix/rvv-testcase.nix
+++ b/nix/rvv-testcase.nix
@@ -1,7 +1,7 @@
-{ stdenv, rv32-clang, glibc_multi, llvmForDev, go, buddy-mlir, ammonite, mill, rvv-codegen }:
-stdenv.mkDerivation {
+{ rv32-clang, glibc_multi, llvmForDev, go, buddy-mlir, ammonite, mill, rvv-codegen }:
+llvmForDev.stdenv.mkDerivation {
   pname = "rvv-testcase";
-  version = "unstable-2023-07-31";
+  version = "unstable-2023-09-04";
   srcs = [
     ../.github/scripts/ci.sc
     ../tests
@@ -36,5 +36,7 @@ stdenv.mkDerivation {
     mkdir -p $out
     cp -r tests-out/{configs,cases} $out
   '';
+  dontPatchELF = true;
+  dontStrip = true;
   __noChroot = true;
 }

--- a/tests/build.sc
+++ b/tests/build.sc
@@ -184,7 +184,7 @@ trait CaseBuilder
 
     // build elf
     val rawElfPath = os.proc("mill", "--no-server", "show", s"$module[$name].elf").call(os.pwd).out.text
-    val elfPath = os.Path(ujson.read(rawElfPath).str.split(":")(2))
+    val elfPath = os.Path(ujson.read(rawElfPath).str.split(":")(3))
 
     // write elf path into test config
     val origConfig = ujson.read(os.read(os.pwd / "configs" / s"$task.json"))


### PR DESCRIPTION
- Fix `caseBuilder` 
- Use llvmPackages_14.stdenv to build the testcase
- Use nix hash path to hash the test case output