### PR TITLE
[nix] use one-step build strategy for buddy-mlir

### DIFF
--- a/nix/buddy-mlir.nix
+++ b/nix/buddy-mlir.nix
@@ -1,68 +1,57 @@
-{ stdenv
-, runCommand
-, lib
-, cmake
-, coreutils
-, python3
-, git
-, fetchFromGitHub
-, ninja
-}:
+{ cmake, ninja, python3, llvmPackages_16, fetchFromGitHub, fetchpatch }:
+# Use clang instead of gcc to build
+llvmPackages_16.stdenv.mkDerivation {
+  pname = "buddy-mlir";
+  version = "unstable-2023-08-28";
 
-let
-  llvm = stdenv.mkDerivation rec {
-    pname = "llvm-project";
-    version = "unstable-2023-05-02";
-    requiredSystemFeatures = [ "big-parallel" ];
-    nativeBuildInputs = [ cmake ninja python3 ];
-    src = fetchFromGitHub {
+  srcs = [
+    # Using git submodule to obtain the llvm source is really slow.
+    # So here I use GitHub archive to download the sources.
+    (fetchFromGitHub {
       owner = "llvm";
-      repo = pname;
+      repo = "llvm-project";
       rev = "8f966cedea594d9a91e585e88a80a42c04049e6c";
-      hash = "sha256-g2cYk3/iyUvmIG0QCQpYmWj4L2H4znx9KbuA5TvIjrc=";
-    };
-    cmakeDir = "../llvm";
-    cmakeFlags = [
-      "-DLLVM_ENABLE_BINDINGS=OFF"
-      "-DLLVM_ENABLE_OCAMLDOC=OFF"
-      "-DLLVM_BUILD_EXAMPLES=OFF"
-      "-DLLVM_ENABLE_PROJECTS=mlir;clang"
-      "-DLLVM_TARGETS_TO_BUILD=host;RISCV"
-      "-DLLVM_INSTALL_UTILS=ON"
-    ];
-    checkTarget = "check-mlir check-clang";
-    postInstall = ''
-      cp include/llvm/Config/config.h $out/include/llvm/Config
-    '';
-  };
-  mlir_dir = runCommand "mlir_dir" { } ''
-    mkdir -p $out
-    ln -s ${llvm.src}/* $out
-    cp -r ${llvm} $out/build
+      sha256 = "sha256-g2cYk3/iyUvmIG0QCQpYmWj4L2H4znx9KbuA5TvIjrc=";
+    })
+    (fetchFromGitHub {
+        owner = "buddy-compiler";
+        repo = "buddy-mlir";
+        rev = "7b420a7c23604de2153b919132a7909f30b2cefb";
+        sha256 = "sha256-m1eabnPo2XXaw7MREt8j9ORQXUvVuWawpJrt2mi/wzM=";
+    })
+  ];
+  sourceRoot = "llvm-project";
+  unpackPhase = ''
+    sourceArray=($srcs)
+    cp -r ''${sourceArray[0]} llvm-project
+    cp -r ''${sourceArray[1]} buddy-mlir
+
+    # Directories copied from nix store are read only
+    chmod -R u+w llvm-project buddy-mlir
   '';
 
-in
-stdenv.mkDerivation rec {
-  pname = "buddy-mlir";
-  version = "unstable-2023-05-26";
-  src = fetchFromGitHub {
-    owner = "buddy-compiler";
-    repo = pname;
-    rev = "74c18e6963cf4781be254d3c5d963b36c0642ba4";
-    hash = "sha256-Wx/QQrELfOT0h4B8hF9EPZKn4yVHBZeYh3Wm85Jpq60=";
-  };
-
-  ninjaFlags = [ "buddy-translate" ];
-
-  requiredSystemFeatures = [ "big-parallel" ];
-
-  nativeBuildInputs = [ cmake ninja ];
-
-  passthru = { inherit llvm; };
-
-  cmakeFlags = [
-    "-DMLIR_DIR=${mlir_dir}/build/lib/cmake/mlir"
-    "-DLLVM_DIR=${mlir_dir}/build/lib/cmake/llvm"
+  prePatch = "pushd $NIX_BUILD_TOP/buddy-mlir";
+  patches = [
+    (fetchpatch {
+       url = "https://github.com/buddy-compiler/buddy-mlir/pull/193.patch";
+       sha256 = "sha256-scj3jtxrUGLBpHsQRoYYJ8ijqJ22pRu9RU2k7EPe95A=";
+     })
   ];
-}
+  postPatch = "popd";
 
+  nativeBuildInputs = [ cmake ninja python3 llvmPackages_16.bintools ];
+
+  cmakeDir = "../llvm";
+  cmakeFlags = [
+    "-DCMAKE_BUILD_TYPE=Release"
+    "-DLLVM_ENABLE_PROJECTS=mlir"
+    "-DLLVM_TARGETS_TO_BUILD=host;RISCV"
+    "-DLLVM_ENABLE_ASSERTIONS=ON"
+    "-DLLVM_USE_LINKER=lld"
+
+    "-DLLVM_EXTERNAL_PROJECTS=buddy-mlir"
+    "-DLLVM_EXTERNAL_BUDDY_MLIR_SOURCE_DIR=../../buddy-mlir"
+  ];
+
+  checkTarget = "check-mlir check-buddy";
+}


### PR DESCRIPTION
This commit use the LLVM external project build strategy to build the buddy-mlir in one-step.