### PR TITLE
[ci] set fail-fast to false for post-pr

### DIFF
--- a/.github/workflows/postpr.yml
+++ b/.github/workflows/postpr.yml
@@ -113,6 +113,8 @@ jobs:
   release:
     runs-on: [self-hosted, linux]
     needs: report
+    strategy:
+      fail-fast: false
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
Diff will exit with return code 1 when it found file differ. And GitHub Action will exit unexpectedly.