### PR TITLE
[emulator] set sv scope before invoking `dpi_error`

### DIFF
--- a/emulator/src/dpi.cc
+++ b/emulator/src/dpi.cc
@@ -38,6 +38,7 @@ void print_perf_summary();
   } catch (std::runtime_error &e) { \
     terminated = true;                \
     LOG(ERROR) << fmt::format("detect exception ({}), gracefully abort simulation", e.what());                 \
+    svSetScope(svGetScopeFromName("TOP.TestBench.verificationModule.dpiError")); \
     dpi_error(e.what());  \
   }
 


### PR DESCRIPTION
The verilator will exit without warning when user calling cpp function which is not in scope. This commit can fix the weird abort behavior of the verilator.