### PR TITLE
performance

### DIFF
--- a/tests/asm/smoke.asm
+++ b/tests/asm/smoke.asm
@@ -1,23 +1,31 @@
 .global test
 test:
     addi x1, x1, 1
-    vsetivli x0, 16, e8, m1, ta, ma
+    li a0, 0x400
+    li a1, 0xc3
+    li a2, 0x10
+    vsetvl x0, a0, a1
     lui x30, 1
     auipc x31, 0
 
 add_test:
-    vadd.vi v0, v1, 10
-    vadd.vv v2, v1, v1
-    vadd.vi v1, v1, 7, v0.t
-    vadd.vx v1, v1, x1
+    vadd.vi v0, v0, 10
+    vadd.vi v16, v8, 11, v0.t
+    vadd.vv v8, v16, v0
+    vadd.vi v16, v8, 7, v0.t
+    vadd.vx v8, v16, x1
 
 chaining_test:
-    vadd.vx v1, v1, x1
-    vxor.vi v7, v5, 7
-    vsll.vi v1, v1, 1
+    vadd.vx v24, v16, x1
+    vxor.vi v8, v24, 7
+    vsll.vi v16, v8, 1
 
 ld_test:
-    vle8.v v4, (x30)
+    vle8.v v16, (x30)
+
+loop:
+    addi a2, a2, -1
+    bnez a2, add_test
 
 exit:
     # Write msimend to exit simulation.

--- a/v/src/Bundles.scala
+++ b/v/src/Bundles.scala
@@ -442,6 +442,13 @@ class VRFReadRequest(regNumBits: Int, offsetBits: Int, instructionIndexBits: Int
   val instructionIndex: UInt = UInt(instructionIndexBits.W)
 }
 
+class VRFReadQueueEntry(regNumBits: Int, offsetBits: Int) extends Bundle {
+  val vs: UInt = UInt(regNumBits.W)
+  val offset: UInt = UInt(offsetBits.W)
+  // for debug
+  val groupIndex: UInt = UInt(4.W)
+}
+
 class VRFWriteRequest(regNumBits: Int, offsetBits: Int, instructionIndexSize: Int, dataPathWidth: Int) extends Bundle {
 
   /** address to access VRF.(v0, v1, v2, ...) */

--- a/v/src/Bundles.scala
+++ b/v/src/Bundles.scala
@@ -633,6 +633,9 @@ class LaneExecuteStage(parameter: LaneParameter)(isLastSlot: Boolean) extends Bu
     * read result of vs2, for instructions that are not executed, pipe from s1
     */
   val pipeData: Option[UInt] = Option.when(isLastSlot)(UInt(parameter.datapathWidth.W))
+
+  // pipe from stage 0
+  val sSendResponse: Option[Bool] = Option.when(isLastSlot)(Bool())
 }
 
 // Record of temporary execution units

--- a/v/src/Bundles.scala
+++ b/v/src/Bundles.scala
@@ -465,6 +465,18 @@ class VRFWriteRequest(regNumBits: Int, offsetBits: Int, instructionIndexSize: In
   val instructionIndex: UInt = UInt(instructionIndexSize.W)
 }
 
+class LSUWriteCheck(regNumBits: Int, offsetBits: Int, instructionIndexSize: Int, dataPathWidth: Int) extends Bundle {
+
+  /** address to access VRF.(v0, v1, v2, ...) */
+  val vd: UInt = UInt(regNumBits.W)
+
+  /** the offset of VRF access. */
+  val offset: UInt = UInt(offsetBits.W)
+
+  /** used to update the record in VRF. */
+  val instructionIndex: UInt = UInt(instructionIndexSize.W)
+}
+
 class VRFWriteReport(param: VRFParam) extends Bundle {
   val vd:        ValidIO[UInt] = Valid(UInt(param.regNumBits.W))
   val vs1:       ValidIO[UInt] = Valid(UInt(param.regNumBits.W))
@@ -481,7 +493,7 @@ class VRFWriteReport(param: VRFParam) extends Bundle {
   // 乘加
   val ma:           Bool = Bool()
   val unOrderWrite: Bool = Bool()
-  // 慢指令 eg. div madc
+  // 慢指令 mask unit
   val slow: Bool = Bool()
   // csr 如果是浮点的就校正为0
   val mul: UInt = UInt(2.W)

--- a/v/src/Bundles.scala
+++ b/v/src/Bundles.scala
@@ -640,7 +640,8 @@ class ExecutionUnitRecord(parameter: LaneParameter)(isLastSlot: Boolean) extends
   val crossReadVS2: Bool = Bool()
   val bordersForMaskLogic: Bool = Bool()
   val mask: UInt = UInt(4.W)
-  val executeIndex: UInt = UInt(2.W)
+  // false -> lsb of cross read group
+  val executeIndex: Bool = Bool()
   val source: Vec[UInt] = Vec(3, UInt(parameter.datapathWidth.W))
   val crossReadSource: Option[UInt] = Option.when(isLastSlot)(UInt((parameter.datapathWidth * 2).W))
   /** groupCounter need use to update `Lane.maskFormatResultForGroup` */
@@ -653,6 +654,8 @@ class SlotRequestToVFU(parameter: LaneParameter) extends Bundle {
   val opcode: UInt = UInt(4.W)
   // mask for carry or borrow
   val mask: UInt = UInt(4.W)
+  // mask for execute
+  val executeMask: UInt = UInt(4.W)
   // eg: vwmaccus, vwmulsu
   val sign0: Bool = Bool()
   val sign: Bool = Bool()
@@ -661,7 +664,7 @@ class SlotRequestToVFU(parameter: LaneParameter) extends Bundle {
   val saturate: Bool = Bool()
   val vxrm: UInt = UInt(2.W)
   val vSew: UInt = UInt(2.W)
-  val shifterSize: UInt = UInt(log2Ceil(parameter.datapathWidth).W)
+  val shifterSize: UInt = UInt((log2Ceil(parameter.datapathWidth) * 4).W)
   val rem:  Bool = Bool()
   val executeIndex: UInt = UInt(2.W)
   val popInit: UInt = UInt(parameter.vlMaxBits.W)

--- a/v/src/Bundles.scala
+++ b/v/src/Bundles.scala
@@ -676,6 +676,7 @@ class SlotRequestToVFU(parameter: LaneParameter) extends Bundle {
   val complete:     Bool = Bool()
   // vm = 0
   val maskType: Bool = Bool()
+  val narrow: Bool = Bool()
   // for float
   val unitSelet: Option[UInt] = Option.when(parameter.fpuEnable)(UInt(2.W))
   val floatMul: Option[Bool] = Option.when(parameter.fpuEnable)(Bool())

--- a/v/src/Bundles.scala
+++ b/v/src/Bundles.scala
@@ -490,6 +490,8 @@ class VRFWriteReport(param: VRFParam) extends Bundle {
   val st:        Bool = Bool()
   val widen:     Bool = Bool()
   val stFinish:  Bool = Bool()
+  // execute finish, wait for write queue clear
+  val wWriteQueueClear: Bool = Bool()
   // 乘加
   val ma:           Bool = Bool()
   val unOrderWrite: Bool = Bool()

--- a/v/src/Lane.scala
+++ b/v/src/Lane.scala
@@ -219,6 +219,9 @@ class Lane(val parameter: LaneParameter) extends Module with SerializableModule[
   /** for RaW, VRF should wait for buffer to be empty. */
   val lsuVRFWriteBufferClear: Bool = IO(Input(Bool()))
 
+  /** for RaW, VRF should wait for cross write bus to be empty. */
+  val crossWriteBusClear: Bool = IO(Input(Bool()))
+
   val writeQueueValid: Bool = IO(Output(Bool()))
   val writeReadyForLsu: Bool = IO(Output(Bool()))
   val vrfReadyToStore: Bool = IO(Output(Bool()))
@@ -1047,6 +1050,7 @@ class Lane(val parameter: LaneParameter) extends Module with SerializableModule[
   vrf.lsuLastReport := lsuLastReport | (instructionFinished & instructionUnrelatedMaskUnitVec.reduce(_ | _))
   vrf.lsuMaskGroupChange := lsuMaskGroupChange
   vrf.lsuWriteBufferClear := lsuVRFWriteBufferClear
+  vrf.crossWriteBusClear := crossWriteBusClear
   vrf.dataInWriteQueue :=
     Mux(crossLaneWriteQueue.io.deq.valid, indexToOH(crossLaneWriteQueue.io.deq.bits.instructionIndex, parameter.chainingSize), 0.U) |
       Mux(topWriteQueue.valid, indexToOH(topWriteQueue.bits.instructionIndex, parameter.chainingSize), 0.U) |

--- a/v/src/Lane.scala
+++ b/v/src/Lane.scala
@@ -563,7 +563,8 @@ class Lane(val parameter: LaneParameter) extends Module with SerializableModule[
         record.laneRequest.instructionIndex(parameter.instructionIndexBits - 2, 0)
       )
       instructionFinishedVec(index) := 0.U
-      instructionUnrelatedMaskUnitVec(index) := Mux(decodeResult(Decoder.maskUnit), 0.U, instructionIndex1H)
+      instructionUnrelatedMaskUnitVec(index) :=
+        Mux(decodeResult(Decoder.maskUnit) && decodeResult(Decoder.readOnly), 0.U, instructionIndex1H)
       when(slotOccupied(index) && pipeClear && pipeFinishVec(index)) {
         slotOccupied(index) := false.B
         instructionFinishedVec(index) := instructionIndex1H
@@ -857,7 +858,8 @@ class Lane(val parameter: LaneParameter) extends Module with SerializableModule[
 
     vrf.write <> maskedWriteUnit.dequeue
     readBeforeMaskedWrite <> maskedWriteUnit.vrfReadRequest
-    writeQueueValid := maskedWriteUnit.enqueue.valid || maskedWriteUnit.dequeue.valid
+    writeQueueValid := maskedWriteUnit.enqueue.valid || maskedWriteUnit.dequeue.valid ||
+      topWriteQueue.valid || vrfWriteChannel.valid
 
     //更新v0
     v0Update.valid := vrf.write.valid && vrf.write.bits.vd === 0.U

--- a/v/src/Lane.scala
+++ b/v/src/Lane.scala
@@ -490,7 +490,7 @@ class Lane(val parameter: LaneParameter) extends Module with SerializableModule[
         slotActive(index) := slotOccupied(index) && !pipeFinishVec(index)
       } else {
         slotActive(index) := slotOccupied(index) && !pipeFinishVec(index) && !slotShiftValid(index) &&
-          !(decodeResult(Decoder.crossRead) || decodeResult(Decoder.crossWrite)) &&
+          !(decodeResult(Decoder.crossRead) || decodeResult(Decoder.crossWrite) || decodeResult(Decoder.widenReduce)) &&
           decodeResult(Decoder.scheduler)
       }
 

--- a/v/src/LaneDiv.scala
+++ b/v/src/LaneDiv.scala
@@ -14,6 +14,7 @@ case class LaneDivParam(datapathWidth: Int) extends VFUParameter with Serializab
   val decodeField: BoolField = Decoder.divider
   val inputBundle = new LaneDivRequest(datapathWidth)
   val outputBundle = new LaneDivResponse(datapathWidth)
+  override val NeedSplit: Boolean = true
 }
 
 class LaneDivRequest(datapathWidth: Int) extends Bundle {

--- a/v/src/LaneDiv.scala
+++ b/v/src/LaneDiv.scala
@@ -15,6 +15,7 @@ case class LaneDivParam(datapathWidth: Int) extends VFUParameter with Serializab
   val inputBundle = new LaneDivRequest(datapathWidth)
   val outputBundle = new LaneDivResponse(datapathWidth)
   override val NeedSplit: Boolean = true
+  override val singleCycle: Boolean = false
 }
 
 class LaneDivRequest(datapathWidth: Int) extends Bundle {

--- a/v/src/LaneFloat.scala
+++ b/v/src/LaneFloat.scala
@@ -18,6 +18,7 @@ case class LaneFloatParam(datapathWidth: Int) extends VFUParameter with Serializ
   val inputBundle = new LaneFloatRequest(datapathWidth)
   val outputBundle = new LaneFloatResponse(datapathWidth)
   override val singleCycle = false
+  override val NeedSplit: Boolean = true
 }
 
 /** UOP encoding

--- a/v/src/LaneShifter.scala
+++ b/v/src/LaneShifter.scala
@@ -14,6 +14,7 @@ case class LaneShifterParameter(dataWidth: Int) extends VFUParameter with Serial
   val decodeField: BoolField = Decoder.shift
   val inputBundle = new LaneShifterReq(this)
   val outputBundle = new LaneShifterResponse(dataWidth)
+  override val NeedSplit: Boolean = true
 }
 
 class LaneShifterReq(param: LaneShifterParameter) extends Bundle {

--- a/v/src/OtherUnit.scala
+++ b/v/src/OtherUnit.scala
@@ -38,6 +38,8 @@ class OtherUnitReq(param: OtherUnitParam) extends Bundle {
   // csr
   val vSew: UInt = UInt(2.W)
   val vxrm: UInt = UInt(2.W)
+  // sew for narrow clip need to be corrected
+  val narrow: Bool = Bool()
 }
 
 class OtherUnitResp(datapathWidth: Int) extends Bundle {
@@ -52,7 +54,7 @@ class OtherUnit(val parameter: OtherUnitParam) extends VFUModule(parameter) with
 
   val ffo:      LaneFFO = Module(new LaneFFO(parameter.datapathWidth))
   val popCount: LanePopCount = Module(new LanePopCount(parameter.datapathWidth))
-  val vSewOH:   UInt = UIntToOH(request.vSew)(2, 0)
+  val vSewOH:   UInt = (UIntToOH(request.vSew) >> request.narrow).asUInt(2, 0)
   // ["", "", "", "", "rgather", "merge", "clip", "mv", "pop", "id"]
   val opcodeOH:         UInt = UIntToOH(request.opcode)(9, 0)
   val isffo:            Bool = opcodeOH(3, 0).orR

--- a/v/src/OtherUnit.scala
+++ b/v/src/OtherUnit.scala
@@ -19,6 +19,7 @@ case class OtherUnitParam(
   val decodeField: BoolField = Decoder.other
   val inputBundle = new OtherUnitReq(this)
   val outputBundle = new OtherUnitResp(datapathWidth)
+  override val NeedSplit: Boolean = true
 }
 
 class OtherUnitReq(param: OtherUnitParam) extends Bundle {

--- a/v/src/V.scala
+++ b/v/src/V.scala
@@ -1217,7 +1217,8 @@ class V(val parameter: VParameter) extends Module with SerializableModule[VParam
       )
 
     lane.lsuMaskGroupChange := lsu.lsuMaskGroupChange
-    lane.lsuVRFWriteBufferClear := !lsu.vrfWritePort(index).valid && busClear
+    lane.lsuVRFWriteBufferClear := !lsu.vrfWritePort(index).valid
+    lane.crossWriteBusClear := busClear
 
     // 处理lane的mask类型请求
     laneSynchronize(index) := lane.laneResponse.valid && !lane.laneResponse.bits.toLSU

--- a/v/src/V.scala
+++ b/v/src/V.scala
@@ -704,7 +704,7 @@ class V(val parameter: VParameter) extends Module with SerializableModule[VParam
       adderRequest.average := false.B
       adderRequest.saturate := false.B
       adderRequest.vxrm := csrRegForMaskUnit.vxrm
-      adderRequest.vSew := 2.U
+      adderRequest.vSew := OHToUInt(sew1HCorrect)
       adder.requestIO.bits := adderRequest.asTypeOf(adder.requestIO.bits)
       adder.requestIO.valid := DontCare
       adder.responseIO.ready := DontCare

--- a/v/src/V.scala
+++ b/v/src/V.scala
@@ -635,7 +635,7 @@ class V(val parameter: VParameter) extends Module with SerializableModule[VParam
         csrRegForMaskUnit.vl > csrRegForMaskUnit.vStart
       mvToVRF.foreach(d => when(requestRegDequeue.fire){d := writeMv})
       // 读后写中的读
-      val needWAR = maskTypeInstruction || border || reduce || readMv
+      val needWAR = maskTypeInstruction || border || (reduce && !popCount) || readMv
       val skipLaneData: Bool = decodeResultReg(Decoder.mv)
       mixedUnit := writeMv || readMv
       maskReadLaneSelect.head := UIntToOH(writeBackCounter)

--- a/v/src/VRF.scala
+++ b/v/src/VRF.scala
@@ -148,6 +148,8 @@ class VRF(val parameter: VRFParam) extends Module with SerializableModule[VRFPar
   /** data in write queue */
   val dataInWriteQueue: UInt = IO(Input(UInt(parameter.chainingSize.W)))
 
+  val crossWriteBusClear: Bool = IO(Input(Bool()))
+
   val lsuMaskGroupChange: UInt = IO(Input(UInt(parameter.chainingSize.W)))
   val writeReadyForLsu: Bool = IO(Output(Bool()))
   val vrfReadyToStore: Bool = IO(Output(Bool()))
@@ -330,7 +332,11 @@ class VRF(val parameter: VRFParam) extends Module with SerializableModule[VRFPar
       when(record.bits.stFinish && lsuWriteBufferClear && record.valid) {
         record.valid := false.B
       }
-      when(record.bits.wWriteQueueClear && !ohCheck(dataInWriteQueue, record.bits.instIndex, parameter.chainingSize)) {
+      when(
+        record.bits.wWriteQueueClear &&
+          !ohCheck(dataInWriteQueue, record.bits.instIndex, parameter.chainingSize) &&
+          (crossWriteBusClear || !record.bits.widen)
+      ) {
         record.valid := false.B
       }
       when(recordEnq(i)) {

--- a/v/src/laneStage/CrossReadUnit.scala
+++ b/v/src/laneStage/CrossReadUnit.scala
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2022 Jiuyang Liu <liu@jiuyang.me>
+
+package v
+import chisel3._
+import chisel3.util._
+
+class CrossReadState extends Bundle {
+  val sSendCrossReadResultLSB: Bool = Bool()
+  val sSendCrossReadResultMSB: Bool = Bool()
+  val wCrossReadLSB: Bool = Bool()
+  val wCrossReadMSB: Bool = Bool()
+}
+class CrossReadUnit(parameter: LaneParameter) extends Module {
+  val dataInputLSB: DecoupledIO[UInt] = IO(Flipped(Decoupled(UInt(parameter.datapathWidth.W))))
+  val dataInputMSB: DecoupledIO[UInt] = IO(Flipped(Decoupled(UInt(parameter.datapathWidth.W))))
+  val laneIndex: UInt = IO(Input(UInt(parameter.laneNumberBits.W)))
+  val dataGroup: UInt = IO(Input(UInt(parameter.groupNumberBits.W)))
+
+  val readBusDequeue: ValidIO[ReadBusData] = IO(
+    Flipped(Valid(new ReadBusData(parameter: LaneParameter))
+  ))
+
+  val readBusRequest: DecoupledIO[ReadBusData] =
+    IO(Decoupled(new ReadBusData(parameter)))
+
+  val crossReadDequeue: DecoupledIO[UInt] = IO(Decoupled(UInt((parameter.datapathWidth * 2).W)))
+  val crossReadStageFree: Bool = IO(Output(Bool()))
+  val crossWriteState = IO(Output(new CrossReadState))
+
+  val stageValid: Bool = RegInit(false.B)
+  val sSendCrossReadResultLSB, sSendCrossReadResultMSB, wCrossReadLSB, wCrossReadMSB = RegInit(true.B)
+  val stateVec: Seq[Bool] = Seq(sSendCrossReadResultLSB, sSendCrossReadResultMSB, wCrossReadLSB, wCrossReadMSB)
+  val sendDataVec: Vec[UInt] = RegInit(VecInit(Seq.fill(2)(0.U(parameter.datapathWidth.W))))
+  val groupCounter: UInt = RegInit(0.U(parameter.groupNumberBits.W))
+  val receiveDataVec: Vec[UInt] = RegInit(VecInit(Seq.fill(2)(0.U(parameter.datapathWidth.W))))
+
+  readBusRequest.valid := stageValid && !(sSendCrossReadResultLSB && sSendCrossReadResultMSB)
+  readBusRequest.bits.sinkIndex := sSendCrossReadResultLSB ## laneIndex(parameter.laneNumberBits - 1, 1)
+  readBusRequest.bits.isTail := laneIndex(0)
+  readBusRequest.bits.sourceIndex := laneIndex
+  readBusRequest.bits.instructionIndex := DontCare
+  readBusRequest.bits.counter := groupCounter
+  readBusRequest.bits.data := Mux(sSendCrossReadResultLSB, sendDataVec.last, sendDataVec.head)
+
+  when(readBusRequest.fire) {
+    when(!sSendCrossReadResultLSB) {
+      sSendCrossReadResultLSB := true.B
+    }.otherwise {
+      sSendCrossReadResultMSB := true.B
+    }
+  }
+
+  when(readBusDequeue.valid) {
+    when(readBusDequeue.bits.isTail) {
+      wCrossReadMSB := true.B
+      receiveDataVec.last := readBusDequeue.bits.data
+    }.otherwise {
+      wCrossReadLSB := true.B
+      receiveDataVec.head := readBusDequeue.bits.data
+    }
+  }
+
+  val deqQueue: Queue[UInt] = Module(new Queue(UInt((parameter.datapathWidth * 2).W), 1))
+  val allStateReady: Bool = stateVec.reduce(_ && _)
+  val stageReady: Bool = !stageValid || (allStateReady && deqQueue.io.enq.ready)
+  val allSourceValid: Bool = dataInputLSB.valid && dataInputMSB.valid
+  val enqueueFire: Bool = stageReady && allSourceValid
+  dataInputLSB.ready := allSourceValid && stageReady
+  dataInputMSB.ready := allSourceValid && stageReady
+
+  when(enqueueFire ^ deqQueue.io.enq.fire) {
+    stageValid := enqueueFire
+  }
+  when(enqueueFire) {
+    stateVec.foreach(_ := false.B)
+    sendDataVec := VecInit(Seq(dataInputLSB.bits, dataInputMSB.bits))
+  }
+  deqQueue.io.enq.bits := receiveDataVec.asUInt
+  deqQueue.io.enq.valid := allStateReady && stageValid
+  crossReadStageFree := (!stageValid) && stateVec.reduce(_ && _) && !deqQueue.io.deq.valid
+  crossReadDequeue <> deqQueue.io.deq
+
+  crossWriteState.sSendCrossReadResultLSB := sSendCrossReadResultLSB
+  crossWriteState.sSendCrossReadResultMSB := sSendCrossReadResultMSB
+  crossWriteState.wCrossReadLSB := wCrossReadLSB
+  crossWriteState.wCrossReadMSB := wCrossReadMSB
+}

--- a/v/src/laneStage/Distributor.scala
+++ b/v/src/laneStage/Distributor.scala
@@ -19,6 +19,7 @@ class Distributor[T <: SlotRequestToVFU, B <: VFUResponseToSlot](enqueue: T, deq
   val responseToSlot: ValidIO[VFUResponseToSlot] = IO(Valid(dequeue))
 
   val requestReg: ValidIO[SlotRequestToVFU] = RegInit(0.U.asTypeOf(Valid(enqueue)))
+  val sendRequestValid: Bool = RegInit(false.B)
   val responseData: UInt = RegInit(0.U(enqueue.src.head.getWidth.W))
   val executeIndex = RegInit(0.U(2.W))
 
@@ -28,6 +29,10 @@ class Distributor[T <: SlotRequestToVFU, B <: VFUResponseToSlot](enqueue: T, deq
 
   when(requestFromSlot.fire ^ responseToSlot.fire) {
     requestReg.valid := requestFromSlot.fire
+  }
+  val lastRequestFire = Wire(Bool())
+  when(requestFromSlot.fire || lastRequestFire) {
+    sendRequestValid := requestFromSlot.fire
   }
 
   // enqueue fire
@@ -75,7 +80,7 @@ class Distributor[T <: SlotRequestToVFU, B <: VFUResponseToSlot](enqueue: T, deq
   /** the bit-level mask of current execution. */
   val bitMaskForExecution: UInt = FillInterleaved(8, byteMaskForExecution)
 
-  def CollapseOperand(data: UInt, enable: Bool = true.B, sign: Bool = false.B): UInt = {
+  def CollapseOperand(data: UInt, sign: Bool = false.B): UInt = {
     val dataMasked: UInt = data & bitMaskForExecution
     // when sew = 0
     val collapse0 = Seq.tabulate(4)(i => dataMasked(8 * i + 7, 8 * i)).reduce(_ | _)
@@ -92,7 +97,7 @@ class Distributor[T <: SlotRequestToVFU, B <: VFUResponseToSlot](enqueue: T, deq
   }
   val signSeq: Seq[Bool] = Seq(requestReg.bits.sign0, requestReg.bits.sign, false.B, false.B)
 
-  requestToVfu.valid := requestReg.valid
+  requestToVfu.valid := sendRequestValid
   requestToVfu.bits := requestReg.bits
   requestToVfu.bits.src := VecInit(
     requestReg.bits.src.zip(signSeq).map{ case (d, s) => CollapseOperand(d, s) }
@@ -103,15 +108,16 @@ class Distributor[T <: SlotRequestToVFU, B <: VFUResponseToSlot](enqueue: T, deq
   val isLastRequest: Bool = Mux1H(vSew1H, Seq(!remainder.orR, !remainder(1, 0).orR, true.B))
   val writeIndex: UInt = Wire(UInt(4.W))
   val isLastResponse: Bool = Wire(Bool())
+  lastRequestFire := isLastRequest && requestToVfu.fire
   writeIndex := executeIndex
   isLastResponse := isLastRequest
   if (multiCycle) {
-    val executeQueue = Module(new Queue(UInt(5.W), 4))
+    val executeQueue = Module(new Queue(UInt(3.W), 4))
     executeQueue.io.enq.bits := isLastRequest ## executeIndex
     executeQueue.io.enq.valid := requestToVfu.fire
     executeQueue.io.deq.ready := responseFromVfu.fire
-    writeIndex := executeQueue.io.deq.bits(3, 0)
-    isLastResponse := executeQueue.io.deq.bits(4)
+    writeIndex := executeQueue.io.deq.bits(1, 0)
+    isLastResponse := executeQueue.io.deq.bits(2) && responseFromVfu.valid && executeQueue.io.deq.valid
   }
 
   // update result

--- a/v/src/laneStage/Distributor.scala
+++ b/v/src/laneStage/Distributor.scala
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2022 Jiuyang Liu <liu@jiuyang.me>
+
+package v
+
+import chisel3._
+import chisel3.util._
+
+
+class Distributor[T <: SlotRequestToVFU, B <: VFUResponseToSlot](enqueue: T, dequeue: B)
+                                                                (multiCycle: Boolean = false) extends Module {
+  // request to vfu
+  val requestToVfu: DecoupledIO[SlotRequestToVFU] = IO(Decoupled(enqueue))
+  // response from vfu
+  val responseFromVfu: ValidIO[VFUResponseToSlot] = IO(Flipped(Valid(dequeue)))
+  // request from LaneExecutionBridge
+  val requestFromSlot: DecoupledIO[SlotRequestToVFU] = IO(Flipped(Decoupled(enqueue)))
+  // response to LaneExecutionBridge
+  val responseToSlot: ValidIO[VFUResponseToSlot] = IO(Valid(dequeue))
+
+  val requestReg: ValidIO[SlotRequestToVFU] = RegInit(0.U.asTypeOf(Valid(enqueue)))
+  val responseData: UInt = RegInit(0.U(enqueue.src.head.getWidth.W))
+  val executeIndex = RegInit(0.U(2.W))
+
+  // Data path width is always 32 when fusion
+  val vSew1HReq: UInt = UIntToOH(requestFromSlot.bits.vSew)(2, 0)
+  val vSew1H = UIntToOH(requestReg.bits.vSew)(2, 0)
+
+  when(requestFromSlot.fire ^ responseToSlot.fire) {
+    requestReg.valid := requestFromSlot.fire
+  }
+
+  // enqueue fire
+  when(requestFromSlot.fire) {
+    requestReg.bits := requestFromSlot.bits
+  }
+
+  // update execute index
+  val nextExecuteIndexForNextGroup: UInt = Mux1H(
+    vSew1HReq(1, 0),
+    Seq(
+      OHToUInt(ffo(requestFromSlot.bits.executeMask)),
+      !requestFromSlot.bits.executeMask(0) ## false.B,
+    )
+  )
+
+  // current one hot depends on execute index
+  val currentOHForExecuteGroup: UInt = UIntToOH(executeIndex)
+  // Remaining to be requested
+  val remainder: UInt = requestReg.bits.executeMask & (~scanRightOr(currentOHForExecuteGroup)).asUInt
+  // Finds the first unfiltered execution.
+  val nextIndex1H: UInt = ffo(remainder)
+  val nextExecuteIndex: UInt = Mux1H(
+    vSew1H(1, 0),
+    Seq(
+      OHToUInt(nextIndex1H),
+      2.U
+    )
+  )
+
+  when(requestToVfu.fire || requestFromSlot.fire) {
+    executeIndex := Mux(requestFromSlot.fire, nextExecuteIndexForNextGroup, nextExecuteIndex)
+  }
+
+  val byteMaskForExecution = Mux1H(
+    vSew1H,
+    Seq(
+      currentOHForExecuteGroup,
+      executeIndex(1) ## executeIndex(1) ##
+        !executeIndex(1) ## !executeIndex(1),
+      15.U(4.W)
+    )
+  )
+
+  /** the bit-level mask of current execution. */
+  val bitMaskForExecution: UInt = FillInterleaved(8, byteMaskForExecution)
+
+  def CollapseOperand(data: UInt, enable: Bool = true.B, sign: Bool = false.B): UInt = {
+    val dataMasked: UInt = data & bitMaskForExecution
+    // when sew = 0
+    val collapse0 = Seq.tabulate(4)(i => dataMasked(8 * i + 7, 8 * i)).reduce(_ | _)
+    // when sew = 1
+    val collapse1 = Seq.tabulate(2)(i => dataMasked(16 * i + 15, 16 * i)).reduce(_ | _)
+    Mux1H(
+      vSew1H,
+      Seq(
+        Fill(25, sign && collapse0(7)) ## collapse0,
+        Fill(17, sign && collapse1(15)) ## collapse1,
+        (sign && data(31)) ## data
+      )
+    )
+  }
+  val signSeq: Seq[Bool] = Seq(requestReg.bits.sign0, requestReg.bits.sign, false.B, false.B)
+
+  requestToVfu.valid := requestReg.valid
+  requestToVfu.bits := requestReg.bits
+  requestToVfu.bits.src := VecInit(
+    requestReg.bits.src.zip(signSeq).map{ case (d, s) => CollapseOperand(d, s) }
+  )
+  requestToVfu.bits.mask := (requestReg.bits.mask & currentOHForExecuteGroup).orR
+  requestToVfu.bits.shifterSize := Mux1H(currentOHForExecuteGroup, cutUInt(requestReg.bits.shifterSize, 5))
+
+  val isLastRequest: Bool = Mux1H(vSew1H, Seq(!remainder.orR, !remainder(1, 0).orR, true.B))
+  val writeIndex: UInt = Wire(UInt(4.W))
+  val isLastResponse: Bool = Wire(Bool())
+  writeIndex := executeIndex
+  isLastResponse := isLastRequest
+  if (multiCycle) {
+    val executeQueue = Module(new Queue(UInt(5.W), 4))
+    executeQueue.io.enq.bits := isLastRequest ## executeIndex
+    executeQueue.io.enq.valid := requestToVfu.fire
+    executeQueue.io.deq.ready := responseFromVfu.fire
+    writeIndex := executeQueue.io.deq.bits(3, 0)
+    isLastResponse := executeQueue.io.deq.bits(4)
+  }
+
+  // update result
+  val writeIndex1H = UIntToOH(writeIndex)
+
+  /** VRF byte level mask */
+  val writeMaskInByte = Mux1H(
+    vSew1H(2, 0),
+    Seq(
+      writeIndex1H,
+      writeIndex(1) ## writeIndex(1) ## !writeIndex(1) ## !writeIndex(1),
+      "b1111".U(4.W)
+    )
+  )
+
+  /** VRF bit level mask */
+  val writeMaskInBit: UInt = FillInterleaved(8, writeMaskInByte)
+
+  /** output of execution unit need to align to VRF in bit level(used in dynamic shift)
+   * TODO: fix me
+   */
+  val dataOffset: UInt = writeIndex ## 0.U(3.W)
+
+  // TODO: this is a dynamic shift logic, but if we switch to parallel execution unit, we don't need it anymore.
+  val executeResult = (responseFromVfu.bits.data << dataOffset).asUInt(enqueue.src.head.getWidth - 1, 0)
+
+  // execute 1,2,4 times based on SEW, only write VRF when 32 bits is ready.
+  val resultUpdate: UInt = (executeResult & writeMaskInBit) | (responseData & (~writeMaskInBit).asUInt)
+
+  when(responseFromVfu.fire) {
+    responseData := resultUpdate
+  }
+
+  requestFromSlot.ready := !requestReg.valid || isLastResponse
+  responseToSlot.valid := isLastResponse && requestReg.valid
+  // todo: clipFail ffoSuccess vxsat exceptionFlags?
+  responseToSlot.bits := DontCare
+  responseToSlot.bits.data := resultUpdate
+}

--- a/v/src/laneStage/Distributor.scala
+++ b/v/src/laneStage/Distributor.scala
@@ -100,6 +100,7 @@ class Distributor[T <: SlotRequestToVFU, B <: VFUResponseToSlot](enqueue: T, deq
 
   requestToVfu.valid := sendRequestValid
   requestToVfu.bits := requestReg.bits
+  requestToVfu.bits.executeIndex := executeIndex
   requestToVfu.bits.src := VecInit(
     requestReg.bits.src.zip(signSeq).map{ case (d, s) => CollapseOperand(d, s) }
   )

--- a/v/src/laneStage/LaneExecutionBridge.scala
+++ b/v/src/laneStage/LaneExecutionBridge.scala
@@ -346,7 +346,7 @@ class LaneExecutionBridge(parameter: LaneParameter, isLastSlot: Boolean) extends
   queue.io.enq.valid :=
     recordQueue.io.deq.valid &&
       ((dataResponse.valid && reduceReady &&
-        (!doubleExecution || executionRecord.executeIndex)) ||
+        (!doubleExecution || recordQueue.io.deq.bits.executeIndex)) ||
       notExecute)
   assert(!queue.io.enq.valid || queue.io.enq.ready)
   dequeue <> queue.io.deq

--- a/v/src/laneStage/LaneExecutionBridge.scala
+++ b/v/src/laneStage/LaneExecutionBridge.scala
@@ -23,6 +23,15 @@ class LaneExecuteResponse(parameter: LaneParameter, isLastSlot: Boolean) extends
   val ffoSuccess: Option[Bool] = Option.when(isLastSlot)(Bool())
 }
 
+class ExecutionBridgeRecordQueue(parameter: LaneParameter, isLastSlot: Boolean) extends Bundle {
+  val bordersForMaskLogic: Bool = Bool()
+  val mask: UInt = UInt((parameter.datapathWidth / 8).W)
+  val groupCounter: UInt = UInt(parameter.groupNumberBits.W)
+  val sSendResponse: Option[Bool] = Option.when(isLastSlot)(Bool())
+  val executeIndex: Bool = Bool()
+  val source2: UInt = UInt(parameter.datapathWidth.W)
+}
+
 class LaneExecutionBridge(parameter: LaneParameter, isLastSlot: Boolean) extends Module {
   // request from lane slot
   val enqueue: DecoupledIO[LaneExecuteRequest] = IO(Flipped(Decoupled(new LaneExecuteRequest(parameter, isLastSlot))))
@@ -37,44 +46,45 @@ class LaneExecutionBridge(parameter: LaneParameter, isLastSlot: Boolean) extends
   val selfCompleted: Bool = IO(Input(Bool()))
 
   val decodeResult: DecodeBundle = state.decodeResult
+  val notExecute: Bool = decodeResult(Decoder.dontNeedExecuteInLane)
 
   val executionRecord: ExecutionUnitRecord = RegInit(0.U.asTypeOf(new ExecutionUnitRecord(parameter)(isLastSlot)))
+  val executionRecordValid = RegInit(false.B)
 
-  val executeIndex1H: UInt = UIntToOH(executionRecord.executeIndex)
-
-  // ffo success in current data group?
-  val ffoSuccess: Option[Bool] = Option.when(isLastSlot)(RegInit(false.B))
   /** result of reduce instruction. */
   val reduceResult: Option[UInt] = Option.when(isLastSlot)(RegInit(0.U(parameter.datapathWidth.W)))
   // execution result from execute unit
   val executionResult = RegInit(0.U(parameter.datapathWidth.W))
-  // todo: only slot 0?
-  val ffoIndexReg: UInt = RegInit(0.U(log2Ceil(parameter.vLen / 8).W))
-  val crossWriteMSB: Option[UInt] = Option.when(isLastSlot)(RegInit(0.U(parameter.datapathWidth.W)))
   val crossWriteLSB: Option[UInt] = Option.when(isLastSlot)(RegInit(0.U(parameter.datapathWidth.W)))
 
   /** mask format result for current `mask group` */
   val maskFormatResultForGroup: Option[UInt] = Option.when(isLastSlot)(RegInit(0.U(parameter.maskGroupWidth.W)))
 
   val fusion: Bool = (decodeResult(Decoder.adder) && !decodeResult(Decoder.red)) || decodeResult(Decoder.multiplier)
-  // Data path width is always 32 when fusion
-  val vSew1HCorrect: UInt = Mux(
-    fusion,
-    Mux(executionRecord.crossReadVS2 && state.vSew1H(0), 2.U(3.W), 4.U(3.W)),
-    state.vSew1H
-  )(2, 0)
-
-  // state register
-  val stageValidReg: Bool = RegInit(false.B)
-  val sSendExecuteRequest: Bool = RegInit(true.B)
-  val wExecuteResult: Bool = RegInit(true.B)
-  val executeRequestStateValid: Bool = !sSendExecuteRequest
-  val executeOver: Bool = sSendExecuteRequest && wExecuteResult
-  dequeue.valid := executeOver && stageValidReg
-  when(enqueue.fire ^ dequeue.fire) {
-    stageValidReg := enqueue.fire
+  // Type widenReduce instructions occupy double the data registers because they need to retain the carry bit.
+  val widenReduce: Bool = decodeResult(Decoder.widenReduce)
+  // todo: Need to collapse the results of combined calculations
+  val reduceReady: Bool = true.B
+  val recordQueueReadyForNoExecute = Wire(Bool())
+  val recordDequeueReady: Bool = (if (isLastSlot) {
+    vfuRequest.ready && (!(decodeResult(Decoder.crossWrite) || widenReduce) || executionRecord.executeIndex)
+  } else {
+    vfuRequest.ready
+  }) || recordQueueReadyForNoExecute
+  val recordDequeueFire: Bool = executionRecordValid && recordDequeueReady
+  when(enqueue.fire ^ recordDequeueFire) {
+    executionRecordValid := enqueue.fire
   }
-  enqueue.ready := !stageValidReg || (executeOver && dequeue.ready)
+  if (isLastSlot) {
+    // update execute index
+    when(enqueue.fire || recordDequeueFire) {
+      // Mux(enqueue.fire, decodeResult(Decoder.crossWrite) && !enqueue.bits.mask(0), true.B)
+      // executeIndex = 0 when enqueue.fire && widenReduce
+      executionRecord.executeIndex :=
+        decodeResult(Decoder.crossWrite) && !enqueue.bits.mask(0) || !enqueue.fire
+    }
+  }
+  enqueue.ready := !executionRecordValid || recordDequeueReady
 
   when(enqueue.fire) {
     executionRecord.crossReadVS2 := decodeResult(Decoder.crossRead) && !decodeResult(Decoder.vwmacc)
@@ -84,130 +94,52 @@ class LaneExecutionBridge(parameter: LaneParameter, isLastSlot: Boolean) extends
     executionRecord.crossReadSource.foreach(_ := enqueue.bits.crossReadSource.get)
     executionRecord.sSendResponse.foreach(_ := enqueue.bits.sSendResponse.get)
     executionRecord.groupCounter := enqueue.bits.groupCounter
-    sSendExecuteRequest := decodeResult(Decoder.dontNeedExecuteInLane)
-    wExecuteResult := decodeResult(Decoder.dontNeedExecuteInLane)
-    ffoSuccess.foreach(_ := false.B)
     // 不满写的先读后写
     executionResult := enqueue.bits.src.last
-  }
-
-  /** the byte-level mask of current execution.
-   * sew match:
-   * 0:
-   * executeIndex match:
-   * 0: 0001
-   * 1: 0010
-   * 2: 0100
-   * 3: 1000
-   * 1:
-   * executeIndex(0) match:
-   * 0: 0011
-   * 1: 1100
-   * 2:
-   * 1111
-   */
-  val byteMaskForExecution = Mux1H(
-    vSew1HCorrect,
-    Seq(
-      executeIndex1H,
-      executionRecord.executeIndex(1) ## executionRecord.executeIndex(1) ##
-        !executionRecord.executeIndex(1) ## !executionRecord.executeIndex(1),
-      15.U(4.W)
-    )
-  )
-
-  /** the bit-level mask of current execution. */
-  val bitMaskForExecution: UInt = FillInterleaved(8, byteMaskForExecution)
-
-  def CollapseOperand(data: UInt, enable: Bool = true.B, sign: Bool = false.B): UInt = {
-    val dataMasked: UInt = data & bitMaskForExecution
-    val select: UInt = Mux(enable, vSew1HCorrect, 4.U(3.W))
-    // when sew = 0
-    val collapse0 = Seq.tabulate(4)(i => dataMasked(8 * i + 7, 8 * i)).reduce(_ | _)
-    // when sew = 1
-    val collapse1 = Seq.tabulate(2)(i => dataMasked(16 * i + 15, 16 * i)).reduce(_ | _)
-    Mux1H(
-      select,
-      Seq(
-        Fill(25, sign && collapse0(7)) ## collapse0,
-        Fill(17, sign && collapse1(15)) ## collapse1,
-        (sign && data(31)) ## data
-      )
-    )
-  }
-
-  // 有2 * sew 的操作数需要折叠
-  def CollapseDoubleOperand(sign: Bool = false.B): UInt = {
-    val doubleBitEnable = FillInterleaved(16, byteMaskForExecution)
-    val doubleDataMasked: UInt = executionRecord.crossReadSource.get & doubleBitEnable
-    val select: UInt = Mux(fusion, 4.U(3.W), false.B ## state.vSew1H(1, 0))
-    // when sew = 0
-    val collapse0 = Seq.tabulate(4)(i => doubleDataMasked(16 * i + 15, 16 * i)).reduce(_ | _)
-    // when sew = 1
-    val collapse1 = Seq.tabulate(2)(i => doubleDataMasked(32 * i + 31, 32 * i)).reduce(_ | _)
-    val dataShift: UInt = 0.U(16.W) ## (executionRecord.crossReadSource.get >> (executionRecord.executeIndex ## 0.U(4.W))).asUInt
-    val fusionData = dataShift(parameter.datapathWidth - 1, 0)
-    Mux1H(
-      select,
-      Seq(
-        Fill(16, sign && collapse0(15)) ## collapse0,
-        collapse1,
-        fusionData
-      )
-    )
   }
 
   /** collapse the dual SEW size operand for cross read.
    * it can be vd or src2.
    */
-  val doubleCollapse = Option.when(isLastSlot)(CollapseDoubleOperand(!decodeResult(Decoder.unsigned1)))
+  val doubleCollapse: Option[UInt] = Option.when(isLastSlot) {
+    val cutCrossReadData: Vec[UInt] = cutUInt(executionRecord.crossReadSource.get, parameter.datapathWidth)
+    Mux(executionRecord.executeIndex, cutCrossReadData(1), cutCrossReadData(0))
+  }
 
-  val dataVec1: Vec[UInt] = cutUInt(executionRecord.source.head, 8)
-  val signVec1: Seq[UInt] = dataVec1.map(d => Fill(8, d(7) && !decodeResult(Decoder.unsigned0)))
-  val sewIsZero = state.vSew1H(0)
-  // sew = 0 把source1里的每一个 element 从 8bit 扩展成16bit
-  //  -> s3 ## d3 ## s2 ## d2 ## s1 ## d1 ## s0 ## d0
-  // sew = 1 把source1里的每一个 element 从 16bit 扩展成32bit
-  //  -> s3 ## s3 ## d3 ## d2 ## s1 ## s1 ## d1 ## d0
-  val source1Extend = signVec1(3) ## Mux(sewIsZero, dataVec1(3), signVec1(3)) ##
-    Mux(sewIsZero, signVec1(2), dataVec1(3)) ## dataVec1(2) ##
-    signVec1(1) ## Mux(sewIsZero, dataVec1(1), signVec1(1)) ##
-    Mux(sewIsZero, signVec1.head, dataVec1(1)) ## dataVec1(0)
-  val source1SelectByExecuteIndex: UInt = Mux(
-    executionRecord.executeIndex === 0.U,
-    cutUInt(source1Extend, 32)(0),
-    cutUInt(source1Extend, 32)(1)
-  )
-  val dataVec2: Vec[UInt] = cutUInt(executionRecord.source(1), 8)
-  val signVec2: Seq[UInt] = dataVec2.map(d => Fill(8, d(7) && !decodeResult(Decoder.unsigned1)))
-  val source2Extend: UInt = signVec2(3) ## Mux(sewIsZero, dataVec2(3), signVec2(3)) ##
-    Mux(sewIsZero, signVec2(2), dataVec2(3)) ## dataVec2(2) ##
-    signVec2(1) ## Mux(sewIsZero, dataVec2(1), signVec2(1)) ##
-    Mux(sewIsZero, signVec2.head, dataVec2(1)) ## dataVec2(0)
-  val source2SelectByExecuteIndex: UInt = Mux(
-    executionRecord.executeIndex === 0.U,
-    cutUInt(source2Extend, 32)(0),
-    cutUInt(source2Extend, 32)(1)
-  )
+  // For cross read, extend 32 bit source1 to 64 bit, then select by executeIndex
+  def dataExtend(data: UInt, sign: Bool): UInt = {
+    val dataVec: Vec[UInt] = cutUInt(data, 8)
+    val signVec: Seq[UInt] = dataVec.map(d => Fill(8, d(7) && sign))
+    val sewIsZero = state.vSew1H(0)
+    // sew = 0 把source1里的每一个 element 从 8bit 扩展成16bit
+    //  -> s3 ## d3 ## s2 ## d2 ## s1 ## d1 ## s0 ## d0
+    // sew = 1 把source1里的每一个 element 从 16bit 扩展成32bit
+    //  -> s3 ## s3 ## d3 ## d2 ## s1 ## s1 ## d1 ## d0
+    val sourceExtend = signVec(3) ## Mux(sewIsZero, dataVec(3), signVec(3)) ##
+      Mux(sewIsZero, signVec(2), dataVec(3)) ## dataVec(2) ##
+      signVec(1) ## Mux(sewIsZero, dataVec(1), signVec(1)) ##
+      Mux(sewIsZero, signVec.head, dataVec(1)) ## dataVec(0)
+    Mux(
+      executionRecord.executeIndex,
+      cutUInt(sourceExtend, 32)(1),
+      cutUInt(sourceExtend, 32)(0)
+    )
+  }
+  val extendSource1: UInt = dataExtend(executionRecord.source.head, !decodeResult(Decoder.unsigned0))
+  val extendSource2: UInt = dataExtend(executionRecord.source(1), !decodeResult(Decoder.unsigned1))
   /** src1 for the execution
    * src1 has three types: V, I, X.
-   * only V type need to use [[CollapseOperand]]
    */
   val normalSource1: UInt =
-    CollapseOperand(
-      // A will be updated every time it is executed, so you can only choose here
-      Mux(
-        decodeResult(Decoder.red) && !decodeResult(Decoder.maskLogic),
-        reduceResult.getOrElse(0.U),
-        executionRecord.source.head
-      ),
-      decodeResult(Decoder.vtype) && (!decodeResult(Decoder.red) || decodeResult(Decoder.maskLogic)),
-      !decodeResult(Decoder.unsigned0)
-    )
-  val finalSource1 = if (isLastSlot) {
     Mux(
-      decodeResult(Decoder.crossWrite) && fusion,
-      source1SelectByExecuteIndex,
+      decodeResult(Decoder.red) && !decodeResult(Decoder.maskLogic),
+      reduceResult.getOrElse(0.U),
+      executionRecord.source.head
+    )
+  val finalSource1: UInt = if (isLastSlot) {
+    Mux(
+      decodeResult(Decoder.crossWrite),
+      extendSource1,
       normalSource1
     )
   } else {
@@ -217,18 +149,18 @@ class LaneExecutionBridge(parameter: LaneParameter, isLastSlot: Boolean) extends
   /** src2 for the execution,
    * need to take care of cross read.
    */
-  val finalSource2 = if (isLastSlot) {
+  val finalSource2: UInt = if (isLastSlot) {
     Mux(
       executionRecord.crossReadVS2,
       doubleCollapse.get,
       Mux(
-        decodeResult(Decoder.crossWrite) && fusion,
-        source2SelectByExecuteIndex,
-        CollapseOperand(executionRecord.source(1), true.B, !decodeResult(Decoder.unsigned1))
+        decodeResult(Decoder.crossWrite) || widenReduce,
+        extendSource2,
+        executionRecord.source(1)
       )
     )
   } else {
-    CollapseOperand(executionRecord.source(1), true.B, !decodeResult(Decoder.unsigned1))
+    executionRecord.source(1)
   }
 
   /** source3 有两种：adc & ma, c等处理mask的时候再处理
@@ -242,38 +174,30 @@ class LaneExecutionBridge(parameter: LaneParameter, isLastSlot: Boolean) extends
     Mux(
       decodeResult(Decoder.vwmacc),
       doubleCollapse.get,
-      CollapseOperand(executionRecord.source(2))
+      executionRecord.source(2)
     )
   } else {
-    CollapseOperand(executionRecord.source(2))
+    executionRecord.source(2)
   }
-
-  val maskAsInput = Mux1H(
-    state.vSew1H(2, 0),
-    Seq(
-      (UIntToOH(executionRecord.executeIndex) & executionRecord.mask).orR,
-      Mux(executionRecord.executeIndex(1), executionRecord.mask(1), executionRecord.mask(0)),
-      executionRecord.mask(0)
-    )
-  )
 
   /** use mask to fix the case that `vl` is not in the multiple of [[parameter.datapathWidth]].
    * it will fill the LSB of mask to `0`, mask it to not execute those elements.
    */
-  val lastGroupMask = scanRightOr(UIntToOH(state.csr.vl(parameter.datapathWidthBits - 1, 0))) >> 1
+  val lastGroupMask: Bits = scanRightOr(UIntToOH(state.csr.vl(parameter.datapathWidthBits - 1, 0))) >> 1
 
   val fullMask: UInt = (-1.S(parameter.datapathWidth.W)).asUInt
   /** if [[executionRecord.bordersForMaskLogic]],
    * use [[lastGroupMask]] to mask the result otherwise use [[fullMask]]. */
-  val maskCorrect = Mux(executionRecord.bordersForMaskLogic, lastGroupMask, fullMask)
+  val maskCorrect: Bits = Mux(executionRecord.bordersForMaskLogic, lastGroupMask, fullMask)
 
   vfuRequest.bits.src := VecInit(Seq(finalSource1, finalSource2, finalSource3, maskCorrect))
   vfuRequest.bits.opcode := decodeResult(Decoder.uop)
   vfuRequest.bits.mask := Mux(
     decodeResult(Decoder.adder),
     Mux(decodeResult(Decoder.maskSource), executionRecord.mask, 0.U(4.W)),
-    maskAsInput || !state.maskType
+    executionRecord.mask | Fill(4, !state.maskType)
   )
+  vfuRequest.bits.executeMask := executionRecord.mask | FillInterleaved(4, state.maskNotMaskedElement)
   vfuRequest.bits.sign0 := !decodeResult(Decoder.unsigned0)
   vfuRequest.bits.sign := !decodeResult(Decoder.unsigned1)
   vfuRequest.bits.reverse := decodeResult(Decoder.reverse)
@@ -285,10 +209,14 @@ class LaneExecutionBridge(parameter: LaneParameter, isLastSlot: Boolean) extends
     state.csr.vSew + 1.U,
     state.csr.vSew
   )
-  vfuRequest.bits.shifterSize := Mux1H(
-    Mux(executionRecord.crossReadVS2, state.vSew1H(1, 0), state.vSew1H(2, 1)),
-    Seq(false.B ## finalSource1(3), finalSource1(4, 3))
-  ) ## finalSource1(2, 0)
+  val shifterSizeBit = Mux(executionRecord.crossReadVS2, state.vSew1H(1, 0), state.vSew1H(2, 1))
+  vfuRequest.bits.shifterSize := VecInit(cutUInt(finalSource1, 8).map(data =>
+    Mux1H(
+      shifterSizeBit,
+      Seq(false.B ## data(3), data(4, 3))
+    ) ## data(2, 0)
+  )).asUInt
+
   vfuRequest.bits.rem := decodeResult(Decoder.uop)(0)
   vfuRequest.bits.executeIndex := executionRecord.executeIndex
   vfuRequest.bits.popInit := reduceResult.getOrElse(0.U)
@@ -302,244 +230,99 @@ class LaneExecutionBridge(parameter: LaneParameter, isLastSlot: Boolean) extends
   // from float csr
   vfuRequest.bits.roundingMode.foreach(_ := state.csr.vxrm)
 
-  vfuRequest.valid := executeRequestStateValid
+  vfuRequest.valid := executionRecordValid
+  //--- record <-> vfu end ---
+  //                        --- record <-> record pipe queue <-> response stage
+  val recordQueue = Module(
+    new Queue(new ExecutionBridgeRecordQueue(parameter, isLastSlot), 2, flow = true)
+  )
+  assert(!vfuRequest.fire || recordQueue.io.enq.ready)
+  recordQueueReadyForNoExecute := notExecute && recordQueue.io.enq.ready
+  recordQueue.io.enq.valid := vfuRequest.valid && (vfuRequest.ready || notExecute)
+  recordQueue.io.enq.bits.bordersForMaskLogic := executionRecord.bordersForMaskLogic
+  recordQueue.io.enq.bits.mask := executionRecord.mask
+  recordQueue.io.enq.bits.groupCounter := executionRecord.groupCounter
+  recordQueue.io.enq.bits.executeIndex := executionRecord.executeIndex
+  recordQueue.io.enq.bits.source2 := executionRecord.source(1)
+  recordQueue.io.enq.bits.sSendResponse.zip(executionRecord.sSendResponse).foreach {
+    case (sink, source) => sink := source
+  }
+  //--- vfu <-> write queue start ---
 
   /** select from VFU, send to [[executionResult]], [[crossWriteLSB]], [[crossWriteMSB]]. */
-  val dataDequeue = dataResponse.bits.data
-
-  val executeRequestFire: Bool = vfuRequest.fire
-
-  val executeResponseFire: Bool = Mux(decodeResult(Decoder.multiCycle), dataResponse.valid, executeRequestFire)
-
-  // mask reg for filtering
-  val maskForFilter = FillInterleaved(4, state.maskNotMaskedElement) |
-    Mux(enqueue.fire, enqueue.bits.mask, executionRecord.mask)
-  // current one hot depends on execute index
-  val currentOHForExecuteGroup: UInt = UIntToOH(executionRecord.executeIndex)
-  // Remaining to be requested
-  val remainder: UInt = maskForFilter & (~scanRightOr(currentOHForExecuteGroup)).asUInt
-  // Finds the first unfiltered execution.
-  val nextIndex1H: UInt = ffo(remainder)
-
-  val isLastRequestForFusionCrossWrite: Bool =
-    executionRecord.executeIndex === 2.U
-  // There are no more left.
-  val isLastRequestForThisGroup: Bool = Mux(
-    fusion && decodeResult(Decoder.crossWrite),
-    isLastRequestForFusionCrossWrite,
-    Mux1H(vSew1HCorrect, Seq(!remainder.orR, !remainder(1, 0).orR, true.B)) || fusion
-  )
-
-  val nextExecuteSelect: UInt = Mux(
-    fusion,
-    Mux(decodeResult(Decoder.crossWrite), 2.U(3.W), 4.U(3.W)),
-    state.vSew1H
-  )(2, 0)
-  /** the next index to execute.
-   *
-   * @note Requests into this disguised execution unit are not executed on the spot
-   * */
-  val nextExecuteIndex: UInt = Mux1H(
-    nextExecuteSelect(1, 0),
-    Seq(
-      OHToUInt(nextIndex1H),
-      // Mux(remainder(0), 0.U, 2.U)
-      !remainder(0) ## false.B
-    )
-  )
-
-  // next execute index if data group change
-  val nextExecuteIndexForNextGroup: UInt = Mux1H(
-    vSew1HCorrect(1, 0),
-    Seq(
-      OHToUInt(ffo(maskForFilter)),
-      (!fusion && !maskForFilter(0)) ## false.B,
-    )
-  )
-
-  // update execute index
-  when(executeRequestFire || enqueue.fire) {
-    executionRecord.executeIndex := Mux(enqueue.fire, nextExecuteIndexForNextGroup, nextExecuteIndex)
-  }
-
-  when(executeRequestFire && isLastRequestForThisGroup) {
-    sSendExecuteRequest := true.B
-  }
-
-  // execute response finish
-  val responseFinish: Bool = Mux(
-    decodeResult(Decoder.multiCycle),
-    executeResponseFire && sSendExecuteRequest,
-    executeRequestFire && isLastRequestForThisGroup
-  )
-
-  when(responseFinish) {
-    wExecuteResult := true.B
-  }
-
-  val multiCycleWriteIndexLatch: UInt =
-    RegEnable(dataResponse.bits.executeIndex, 0.U(2.W), dataResponse.valid)
-  val multiCycleWriteIndex = Mux(dataResponse.valid, dataResponse.bits.executeIndex, multiCycleWriteIndexLatch)
-  /** the index to write to VRF in [[parameter.dataPathByteWidth]].
-   * for long latency pipe, the index will follow the pipeline.
-   */
-  val writeIndex = Mux(
-    decodeResult(Decoder.multiCycle),
-    multiCycleWriteIndex,
-    executionRecord.executeIndex
-  )
-
-  val writeIndex1H = UIntToOH(writeIndex)
-
-  /** VRF byte level mask */
-  val writeMaskInByte = Mux1H(
-    vSew1HCorrect(2, 0),
-    Seq(
-      writeIndex1H,
-      writeIndex(1) ## writeIndex(1) ## !writeIndex(1) ## !writeIndex(1),
-      "b1111".U(4.W)
-    )
-  )
-
-  /** VRF bit level mask */
-  val writeMaskInBit: UInt = FillInterleaved(8, writeMaskInByte)
-
-  /** output of execution unit need to align to VRF in bit level(used in dynamic shift)
-   * TODO: fix me
-   */
-  val dataOffset: UInt = writeIndex ## 0.U(3.W)
-
-  // TODO: this is a dynamic shift logic, but if we switch to parallel execution unit, we don't need it anymore.
-  val executeResult = (dataDequeue << dataOffset).asUInt(parameter.datapathWidth - 1, 0)
-
-  // execute 1,2,4 times based on SEW, only write VRF when 32 bits is ready.
-  val resultUpdate: UInt = (executeResult & writeMaskInBit) | (executionResult & (~writeMaskInBit).asUInt)
+  val dataDequeue: UInt = Mux(notExecute, recordQueue.io.deq.bits.source2, dataResponse.bits.data)
 
   // update execute result
-  when(executeResponseFire) {
+  when(dataResponse.valid) {
     // update the [[executionResult]]
-    executionResult := resultUpdate
+    executionResult := dataDequeue
 
-    // the find first one instruction is finished in this lane
-    ffoSuccess.foreach(_ := dataResponse.bits.ffoSuccess)
-    when(dataResponse.bits.ffoSuccess && !selfCompleted) {
-      ffoIndexReg := executionRecord.groupCounter ## Mux1H(
-        state.vSew1H,
-        Seq(
-          executionRecord.executeIndex ## dataResponse.bits.data(2, 0),
-          executionRecord.executeIndex(1) ## dataResponse.bits.data(3, 0),
-          dataResponse.bits.data(4, 0)
-        )
-      )
-    }
-
-    // update cross-lane write data
-    /** sew:
-     * 0:
-     * executeIndex:
-     * 0: mask = 0011, head
-     * 1: mask = 1100, head
-     * 2: mask = 0011, tail
-     * 3: mask = 1100, tail
-     * 1:
-     * executeIndex:
-     * 0: mask = 1111, head
-     * 2: mask = 1111, tail
-     *
-     * 2: not valid in SEW = 2
-     */
-    if (isLastSlot) {
-      val fusionMSBUpdate = fusion && executionRecord.executeIndex =/= 0.U
-      val fusionLSBUpdate = fusion && executionRecord.executeIndex === 0.U
-      when(executionRecord.executeIndex(1)) {
-        crossWriteMSB.foreach { crossWriteData =>
-          // update tail
-          crossWriteData :=
-            Mux(
-              state.csr.vSew(0) || fusionMSBUpdate,
-              dataDequeue(parameter.datapathWidth - 1, parameter.halfDatapathWidth),
-              Mux(
-                executionRecord.executeIndex(0),
-                dataDequeue(parameter.halfDatapathWidth - 1, 0),
-                crossWriteData(parameter.datapathWidth - 1, parameter.halfDatapathWidth)
-              )
-            ) ## Mux(
-              !executionRecord.executeIndex(0) || state.csr.vSew(0) || fusionMSBUpdate,
-              dataDequeue(parameter.halfDatapathWidth - 1, 0),
-              crossWriteData(parameter.halfDatapathWidth - 1, 0)
-            )
-        }
-      }.otherwise {
-        crossWriteLSB.foreach { crossWriteData =>
-          crossWriteData :=
-            Mux(
-              state.csr.vSew(0) || fusionLSBUpdate,
-              dataDequeue(parameter.datapathWidth - 1, parameter.halfDatapathWidth),
-              Mux(
-                executionRecord.executeIndex(0),
-                dataDequeue(parameter.halfDatapathWidth - 1, 0),
-                crossWriteData(parameter.datapathWidth - 1, parameter.halfDatapathWidth)
-              )
-            ) ## Mux(
-              !executionRecord.executeIndex(0) || state.csr.vSew(0) || fusionLSBUpdate,
-              dataDequeue(parameter.halfDatapathWidth - 1, 0),
-              crossWriteData(parameter.halfDatapathWidth - 1, 0)
-            )
-        }
-      }
+    crossWriteLSB.foreach { crossWriteData =>
+      crossWriteData := dataDequeue
     }
   }
 
+  /** update value for [[maskFormatResultForGroup]] */
+  val maskFormatResultUpdate: Option[UInt] = Option.when(isLastSlot)(Wire(UInt(parameter.datapathWidth.W)))
+
+  val updateReduceResult: Option[UInt] = Option.when(isLastSlot)(Wire(UInt(parameter.datapathWidth.W)))
   // update mask result
   if (isLastSlot) {
     val maskResult: UInt = dataResponse.bits.adderMaskResp
     /** update value for [[maskFormatResultUpdate]],
      * it comes from ALU.
      */
-    val elementMaskFormatResult = Mux1H(
-      state.vSew1H(2, 0),
-      Seq(
-        // 32bit, 4 bit per data group, it will had 8 data groups -> executeIndex1H << 4 * groupCounter(2, 0)
-        maskResult << (executionRecord.groupCounter(2, 0) ## 0.U(2.W)),
-        // 2 bit per data group, it will had 16 data groups -> executeIndex1H << 2 * groupCounter(3, 0)
-        maskResult(1, 0) <<
-          (executionRecord.groupCounter(3, 0) ## false.B),
-        // 1 bit per data group, it will had 32 data groups -> executeIndex1H << 1 * groupCounter(4, 0)
-        maskResult(0) << executionRecord.groupCounter(4, 0)
-      )
-    ).asUInt
+    val elementMaskFormatResult = (maskResult << (recordQueue.io.deq.bits.groupCounter(2, 0) ## 0.U(2.W))).asUInt
 
-    /** update value for [[maskFormatResultForGroup]] */
-    val maskFormatResultUpdate: UInt = maskFormatResultForGroup.get | elementMaskFormatResult
+    maskFormatResultUpdate.get := maskFormatResultForGroup.get | elementMaskFormatResult
 
-    val updateMaskResult: Option[Bool] = executionRecord.sSendResponse.map(!_ && dequeue.fire)
+    val updateMaskResult: Option[Bool] = recordQueue.io.deq.bits.sSendResponse.map(!_ && dequeue.fire)
 
     // update `maskFormatResultForGroup`
-    when(executeResponseFire || updateMaskResult.get) {
-      maskFormatResultForGroup.foreach(_ := Mux(executeResponseFire, maskFormatResultUpdate, 0.U))
+    when(dataResponse.valid || updateMaskResult.get) {
+      maskFormatResultForGroup.foreach(_ := Mux(dataResponse.valid, maskFormatResultUpdate.get, 0.U))
     }
     // masked element don't update 'reduceResult'
-    val updateReduceResult = (state.maskNotMaskedElement || maskAsInput) && executeResponseFire
+    val reduceUpdateByteMask: UInt = Mux1H(
+      state.vSew1H,
+      Seq(
+        recordQueue.io.deq.bits.mask,
+        FillInterleaved(2, recordQueue.io.deq.bits.mask(1, 0)),
+        FillInterleaved(4, recordQueue.io.deq.bits.mask(0))
+      )
+    )
+    val reduceUpdateBitMask = FillInterleaved(8, reduceUpdateByteMask)
+    updateReduceResult.get := (dataDequeue & reduceUpdateBitMask) | (reduceResult.get & ~reduceUpdateBitMask)
     // update `reduceResult`
-    when(updateReduceResult || updateMaskResult.get) {
-      reduceResult.get := Mux(updateReduceResult && decodeResult(Decoder.red), dataDequeue, 0.U)
+    when(dataResponse.valid || updateMaskResult.get) {
+      reduceResult.get := Mux(dataResponse.valid && decodeResult(Decoder.red), updateReduceResult.get, 0.U)
     }
   }
 
+  // queue before dequeue
+  val queue: Queue[LaneExecuteResponse] = Module(new Queue(new LaneExecuteResponse(parameter, isLastSlot), 4))
   if (isLastSlot) {
-    dequeue.bits.data := Mux(
+    queue.io.enq.bits.data := Mux(
       decodeResult(Decoder.maskDestination),
-      maskFormatResultForGroup.get,
+      maskFormatResultUpdate.get,
       Mux(
         decodeResult(Decoder.red),
-        reduceResult.get,
-        executionResult
+        updateReduceResult.get,
+        dataDequeue
       )
     )
   } else {
-    dequeue.bits.data := executionResult
+    queue.io.enq.bits.data := dataDequeue
   }
-  dequeue.bits.ffoIndex := ffoIndexReg
-  dequeue.bits.crossWriteData.foreach(_ := VecInit((crossWriteLSB ++ crossWriteMSB).toSeq))
-  dequeue.bits.ffoSuccess.foreach(_ := ffoSuccess.get)
+  queue.io.enq.bits.ffoIndex := recordQueue.io.deq.bits.groupCounter ## dataResponse.bits.data(4, 0)
+  queue.io.enq.bits.crossWriteData.foreach(_ := VecInit((crossWriteLSB ++ Seq(dataDequeue)).toSeq))
+  queue.io.enq.bits.ffoSuccess.foreach(_ := dataResponse.bits.ffoSuccess)
+  recordQueue.io.deq.ready := dataResponse.valid || (notExecute && queue.io.enq.ready)
+  queue.io.enq.valid :=
+    recordQueue.io.deq.valid &&
+      ((dataResponse.valid && reduceReady &&
+      (!decodeResult(Decoder.crossRead) || recordQueue.io.deq.bits.executeIndex)) ||
+      notExecute)
+  assert(!queue.io.enq.valid || queue.io.enq.ready)
+  dequeue <> queue.io.deq
 }

--- a/v/src/laneStage/LaneExecutionBridge.scala
+++ b/v/src/laneStage/LaneExecutionBridge.scala
@@ -195,12 +195,13 @@ class LaneExecutionBridge(parameter: LaneParameter, isLastSlot: Boolean) extends
    * use [[lastGroupMask]] to mask the result otherwise use [[fullMask]]. */
   val maskCorrect: Bits = Mux(executionRecord.bordersForMaskLogic, lastGroupMask, fullMask)
 
+  val maskExtend = Mux(state.vSew1H(1), FillInterleaved(2, executionRecord.mask(1, 0)), executionRecord.mask)
   vfuRequest.bits.src := VecInit(Seq(finalSource1, finalSource2, finalSource3, maskCorrect))
   vfuRequest.bits.opcode := decodeResult(Decoder.uop)
   vfuRequest.bits.mask := Mux(
     decodeResult(Decoder.adder),
     Mux(decodeResult(Decoder.maskSource), executionRecord.mask, 0.U(4.W)),
-    executionRecord.mask | Fill(4, !state.maskType)
+    maskExtend | Fill(4, !state.maskType)
   )
   vfuRequest.bits.executeMask := executionRecord.mask | FillInterleaved(4, state.maskNotMaskedElement)
   vfuRequest.bits.sign0 := !decodeResult(Decoder.unsigned0)

--- a/v/src/laneStage/LaneStage1.scala
+++ b/v/src/laneStage/LaneStage1.scala
@@ -222,12 +222,12 @@ class LaneStage1(parameter: LaneParameter, isLastSlot: Boolean) extends
     // the priority of `sRead1` is higher than `sCrossReadLSB`
     when(readPortFire1) {
       sRead1 := true.B
-      sCrossReadLSB.foreach(d => d := sRead1)
+      sCrossReadLSB.foreach(d => d := sRead1 || d)
     }
     // the priority of `sRead2` is higher than `sCrossReadMSB`
     when(readPortFire2) {
       sRead2 := true.B
-      sCrossReadMSB.foreach(d => d := sRead2)
+      sCrossReadMSB.foreach(d => d := sRead2 || d)
     }
 
     readBusDequeue.foreach { crossReadDequeue =>

--- a/v/src/laneStage/LaneStage1.scala
+++ b/v/src/laneStage/LaneStage1.scala
@@ -231,10 +231,8 @@ class LaneStage1(parameter: LaneParameter, isLastSlot: Boolean) extends Module {
   // replace instructionIndex
   readBusRequest.foreach(_.bits.instructionIndex := state.instructionIndex)
 
-  val repeatScalarData: Bool = state.decodeResult(Decoder.adder) || state.decodeResult(Decoder.multiplier)
-  val scalarDataSelect: UInt = Mux(repeatScalarData, state.vSew1H, 4.U(3.W))
   val scalarDataRepeat: UInt = Mux1H(
-    scalarDataSelect,
+    state.vSew1H,
     Seq(
       Fill(4, readFromScalar(7, 0)),
       Fill(2, readFromScalar(15, 0)),

--- a/v/src/laneStage/MaskedWrite.scala
+++ b/v/src/laneStage/MaskedWrite.scala
@@ -17,6 +17,7 @@ class MaskedWrite(parameter: LaneParameter) extends Module {
   val vrfReadRequest: DecoupledIO[VRFReadRequest] = IO(Decoupled(
     new VRFReadRequest(parameter.vrfParam.regNumBits, parameter.vrfOffsetBits, parameter.instructionIndexBits)
   ))
+  val maskedWrite1H: UInt = IO(Output(UInt(parameter.chainingSize.W)))
   /** VRF read result for each slot,
    * 3 is for [[source1]] [[source2]] [[source3]]
    */
@@ -39,4 +40,6 @@ class MaskedWrite(parameter: LaneParameter) extends Module {
   dequeue <> writeQueue
   val maskFill: UInt = FillInterleaved(8, writeQueue.bits.mask)
   dequeue.bits.data := writeQueue.bits.data & maskFill | (dataSelect & (~maskFill))
+  maskedWrite1H :=
+    Mux(writeQueue.valid, indexToOH(writeQueue.bits.instructionIndex, parameter.chainingSize), 0.U)
 }

--- a/v/src/laneStage/VrfReadPipe.scala
+++ b/v/src/laneStage/VrfReadPipe.scala
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2022 Jiuyang Liu <liu@jiuyang.me>
+
+package v
+import chisel3._
+import chisel3.util._
+
+class VrfReadPipe(parameter: LaneParameter, arbitrate: Boolean = false) extends Module {
+
+  val enqEntryType: VRFReadQueueEntry = new VRFReadQueueEntry(parameter.vrfParam.regNumBits, parameter.vrfOffsetBits)
+  // for vs2 | vd
+  val enqueue: DecoupledIO[VRFReadQueueEntry] = IO(Flipped(Decoupled(enqEntryType)))
+
+  // for cross read
+  val contender: Option[DecoupledIO[VRFReadQueueEntry]] = Option.when(arbitrate)(IO(Flipped(Decoupled(enqEntryType))))
+
+  // read port
+  val vrfReadRequest: DecoupledIO[VRFReadRequest] = IO(
+    Decoupled(
+      new VRFReadRequest(parameter.vrfParam.regNumBits, parameter.vrfOffsetBits, parameter.instructionIndexBits)
+    )
+  )
+
+  // read result
+  val vrfReadResult: UInt = IO(Input(UInt(parameter.datapathWidth.W)))
+
+  val dequeue: DecoupledIO[UInt] = IO(Decoupled(UInt(parameter.datapathWidth.W)))
+  val dequeueChoose: Option[Bool] = Option.when(arbitrate)(IO(Output(Bool())))
+
+  // arbitrate
+  val reqArbitrate = Module(new RRArbiter(enqEntryType, if(arbitrate) 2 else 1))
+
+  (Seq(enqueue) ++ contender).zip(reqArbitrate.io.in).foreach { case (source, sink) => sink <> source }
+
+  val dataStageFree = Wire(Bool())
+  // access read port
+  vrfReadRequest.valid := reqArbitrate.io.out.valid && dataStageFree
+  vrfReadRequest.bits.vs := reqArbitrate.io.out.bits.vs
+  vrfReadRequest.bits.offset := reqArbitrate.io.out.bits.offset
+  vrfReadRequest.bits.instructionIndex := DontCare
+  reqArbitrate.io.out.ready := dataStageFree && vrfReadRequest.ready
+
+  // read pipe stage1
+  val readPortFire: Bool = vrfReadRequest.fire
+  val stage1Valid: Bool = RegInit(false.B)
+  val ReadFireNext: Bool = RegNext(readPortFire)
+  val dataReg: UInt = RegEnable(vrfReadResult, 0.U(parameter.datapathWidth.W), ReadFireNext)
+  val stage1Choose: Option[Bool] = Option.when(arbitrate)(RegEnable(enqueue.fire, false.B, readPortFire))
+
+  stage1Choose.foreach {d => when(readPortFire) { d := enqueue.fire}}
+  when(readPortFire ^ dequeue.fire) {
+    stage1Valid := readPortFire
+  }
+
+  dataStageFree := !stage1Valid || dequeue.ready
+
+  dequeueChoose.zip(stage1Choose).foreach { case (io, data) => io := data }
+  dequeue.valid := stage1Valid
+  dequeue.bits := Mux(ReadFireNext, vrfReadResult, dataReg)
+}


### PR DESCRIPTION
- [rtl] Remove unnecessary reads.
- [rtl] Detect load unit write-after-write conflicts in advance.
- [test] Change smoke.asm length to test the performance of accessing vrf.
