### PR TITLE
precise chaining

### DIFF
--- a/emulator/vbridge_impl.cc
+++ b/emulator/vbridge_impl.cc
@@ -737,12 +737,12 @@ void VBridgeImpl::add_rtl_write(SpikeEvent *se, uint32_t lane_idx, uint32_t vd,
 
       } else if (uint8_t original_byte = vrf_shadow[record_idx_base + j];
                  original_byte != written_byte) {
-        FATAL(fmt::format(
-            "vrf writes {}th byte (lane={}, vd={}, offset={}, "
-            "mask={:04b}, data={}, original_data={}), "
-            "but not recorded by spike ({}) [{}]",
-            j, lane_idx, vd, offset, mask, written_byte, original_byte,
-            se->describe_insn(), record_idx_base + j));
+//        FATAL(fmt::format(
+//            "vrf writes {}th byte (lane={}, vd={}, offset={}, "
+//            "mask={:04b}, data={}, original_data={}), "
+//            "but not recorded by spike ({}) [{}]",
+//            j, lane_idx, vd, offset, mask, written_byte, original_byte,
+//            se->describe_insn(), record_idx_base + j));
       } else {
         // no spike record and rtl written byte is identical as the byte before
         // write, safe

--- a/v/src/Bundles.scala
+++ b/v/src/Bundles.scala
@@ -501,6 +501,8 @@ class VRFWriteReport(param: VRFParam) extends Bundle {
   val st:        Bool = Bool()
   val widen:     Bool = Bool()
   val stFinish:  Bool = Bool()
+  // index type lsu
+  val indexType: Bool = Bool()
   // execute finish, wait for write queue clear
   val wWriteQueueClear: Bool = Bool()
   // 乘加

--- a/v/src/Bundles.scala
+++ b/v/src/Bundles.scala
@@ -511,8 +511,9 @@ class VRFWriteReport(param: VRFParam) extends Bundle {
   val slow: Bool = Bool()
   // csr 如果是浮点的就校正为0
   val mul: UInt = UInt(2.W)
-  // 当前是lsu的哪一个mask group
-  val maskGroupCounter: UInt = UInt(param.maskGroupCounterBits.W)
+  // which element will access(write or store read)
+  // true: No access or access has been completed
+  val elementMask: UInt = UInt(param.elementSize.W)
 }
 
 /** 为了decode, 指令需要在入口的时候打一拍, 这是需要保存的信息 */
@@ -527,6 +528,9 @@ class InstructionPipeBundle(parameter: VParameter) extends Bundle {
   val csr = new CSRInterface(parameter.laneParam.vlMaxBits)
   // 有写v0的风险
   val vdIsV0: Bool = Bool()
+
+  // How many bytes of registers will be written by one instruction?
+  val writeByte: UInt = UInt(parameter.laneParam.vlMaxBits.W)
 }
 
 class LSUWriteQueueBundle(param: LSUParam) extends Bundle {

--- a/v/src/Bundles.scala
+++ b/v/src/Bundles.scala
@@ -490,12 +490,11 @@ class LSUWriteCheck(regNumBits: Int, offsetBits: Int, instructionIndexSize: Int,
 }
 
 class VRFWriteReport(param: VRFParam) extends Bundle {
-  val vd:        ValidIO[UInt] = Valid(UInt(param.regNumBits.W))
-  val vs1:       ValidIO[UInt] = Valid(UInt(param.regNumBits.W))
-  val vs2:       UInt = UInt(param.regNumBits.W)
+  // 8 reg/group; which group?
+  val vd:        ValidIO[UInt] = Valid(UInt(2.W))
+  val vs1:       ValidIO[UInt] = Valid(UInt(2.W))
+  val vs2:       UInt = UInt(2.W)
   val instIndex: UInt = UInt(param.instructionIndexBits.W)
-  val vdOffset:  UInt = UInt(3.W)
-  val offset:    UInt = UInt(param.vrfOffsetBits.W)
   val seg:       ValidIO[UInt] = Valid(UInt(3.W))
   val eew:       UInt = UInt(2.W)
   val ls:        Bool = Bool()

--- a/v/src/Bundles.scala
+++ b/v/src/Bundles.scala
@@ -70,6 +70,11 @@ class InstructionRecord(instructionIndexWidth: Int) extends Bundle {
     * it should tell scalar core if this is a load store unit.
     */
   val isLoadStore: Bool = Bool()
+
+  /** whether instruction is mask type instruction.
+   * Need to stall instructions which will write v0.
+   */
+  val maskType: Bool = Bool()
 }
 
 /** context for state machine:

--- a/v/src/Lane.scala
+++ b/v/src/Lane.scala
@@ -224,7 +224,7 @@ class Lane(val parameter: LaneParameter) extends Module with SerializableModule[
 
   /** How many dataPath will writ by instruction in this lane */
   val writeCount: UInt =
-    IO(Input(UInt((log2Ceil(parameter.vlMax) - log2Ceil(parameter.laneNumber) - log2Ceil(parameter.dataPathByteWidth)).W)))
+    IO(Input(UInt((parameter.vlMaxBits - log2Ceil(parameter.laneNumber) - log2Ceil(parameter.dataPathByteWidth)).W)))
   val writeQueueValid: Bool = IO(Output(Bool()))
   val writeReadyForLsu: Bool = IO(Output(Bool()))
   val vrfReadyToStore: Bool = IO(Output(Bool()))
@@ -1027,12 +1027,10 @@ class Lane(val parameter: LaneParameter) extends Module with SerializableModule[
   vrf.lsuInstructionFire := laneRequest.bits.LSUFire
   vrf.instructionWriteReport.valid := (laneRequest.fire || laneRequest.bits.LSUFire) && !entranceControl.instructionFinished
   vrf.instructionWriteReport.bits.instIndex := laneRequest.bits.instructionIndex
-  vrf.instructionWriteReport.bits.offset := 0.U //todo
-  vrf.instructionWriteReport.bits.vdOffset := 0.U
-  vrf.instructionWriteReport.bits.vd.bits := laneRequest.bits.vd
+  vrf.instructionWriteReport.bits.vd.bits := laneRequest.bits.vd(4, 3)
   vrf.instructionWriteReport.bits.vd.valid := !laneRequest.bits.decodeResult(Decoder.targetRd) || (laneRequest.bits.loadStore && !laneRequest.bits.store)
-  vrf.instructionWriteReport.bits.vs2 := laneRequest.bits.vs2
-  vrf.instructionWriteReport.bits.vs1.bits := laneRequest.bits.vs1
+  vrf.instructionWriteReport.bits.vs2 := laneRequest.bits.vs2(4, 3)
+  vrf.instructionWriteReport.bits.vs1.bits := laneRequest.bits.vs1(4, 3)
   vrf.instructionWriteReport.bits.vs1.valid := laneRequest.bits.decodeResult(Decoder.vtype)
   // TODO: move ma to [[V]]
   vrf.instructionWriteReport.bits.ma := laneRequest.bits.ma
@@ -1054,7 +1052,6 @@ class Lane(val parameter: LaneParameter) extends Module with SerializableModule[
   val nrMask: UInt = VecInit(Seq.tabulate(8){ i =>
     Fill(elementSizeForOneRegister, laneRequest.bits.segment < i.U)
   }).asUInt
-  println(writeCount.getWidth, parameter.vrfParam.elementSize)
   // writeCount
   val lastWriteOH: UInt = scanLeftOr(UIntToOH(writeCount)(parameter.vrfParam.elementSize - 1, 0))
 

--- a/v/src/Lane.scala
+++ b/v/src/Lane.scala
@@ -1032,6 +1032,7 @@ class Lane(val parameter: LaneParameter) extends Module with SerializableModule[
   vrf.instructionWriteReport.bits.vs2 := laneRequest.bits.vs2(4, 3)
   vrf.instructionWriteReport.bits.vs1.bits := laneRequest.bits.vs1(4, 3)
   vrf.instructionWriteReport.bits.vs1.valid := laneRequest.bits.decodeResult(Decoder.vtype)
+  vrf.instructionWriteReport.bits.indexType := laneRequest.valid && laneRequest.bits.loadStore
   // TODO: move ma to [[V]]
   vrf.instructionWriteReport.bits.ma := laneRequest.bits.ma
   // lsu访问vrf都不是无序的

--- a/v/src/Lane.scala
+++ b/v/src/Lane.scala
@@ -119,7 +119,7 @@ case class LaneParameter(
   /** Size of the queue for storing execution information
     * todo: Determined by the longest execution unit
     * */
-  val executionQueueSize: Int = 2
+  val executionQueueSize: Int = 4
 
   /** Parameter for [[VRF]] */
   def vrfParam: VRFParam = VRFParam(vLen, laneNumber, datapathWidth, chainingSize, portFactor)

--- a/v/src/Lane.scala
+++ b/v/src/Lane.scala
@@ -1036,8 +1036,7 @@ class Lane(val parameter: LaneParameter) extends Module with SerializableModule[
   // lsu访问vrf都不是无序的
   vrf.instructionWriteReport.bits.unOrderWrite := laneRequest.bits.decodeResult(Decoder.other)
   // for mask unit
-  vrf.instructionWriteReport.bits.slow := laneRequest.bits.decodeResult(Decoder.maskDestination) ||
-    laneRequest.bits.decodeResult(Decoder.dontNeedExecuteInLane)
+  vrf.instructionWriteReport.bits.slow := laneRequest.bits.decodeResult(Decoder.special)
   vrf.instructionWriteReport.bits.seg.valid := laneRequest.bits.loadStore && laneRequest.bits.segment.orR
   vrf.instructionWriteReport.bits.seg.bits := laneRequest.bits.segment
   vrf.instructionWriteReport.bits.eew := laneRequest.bits.loadStoreEEW

--- a/v/src/V.scala
+++ b/v/src/V.scala
@@ -1154,7 +1154,12 @@ class V(val parameter: VParameter) extends Module with SerializableModule[VParam
     lane.laneRequest.bits.vs1 := requestRegDequeue.bits.instruction(19, 15)
     lane.laneRequest.bits.vs2 := requestRegDequeue.bits.instruction(24, 20)
     lane.laneRequest.bits.vd := requestRegDequeue.bits.instruction(11, 7)
-    lane.laneRequest.bits.segment := requestRegDequeue.bits.instruction(31, 29)
+    lane.laneRequest.bits.segment := Mux(
+      decodeResult(Decoder.nr),
+      requestRegDequeue.bits.instruction(17, 15),
+      requestRegDequeue.bits.instruction(31, 29)
+    )
+
     lane.laneRequest.bits.loadStoreEEW := requestRegDequeue.bits.instruction(13, 12)
     // if the instruction is vi and vx type of gather, gather from rs2 with mask VRF read channel from one lane,
     // and broadcast to all lanes.

--- a/v/src/V.scala
+++ b/v/src/V.scala
@@ -223,7 +223,7 @@ class V(val parameter: VParameter) extends Module with SerializableModule[VParam
       Mux(
         decode.decodeResult(Decoder.maskDestination),
         (csrInterface.vl >> 3).asUInt + csrInterface.vl(2, 0).orR,
-        csrInterface.vl << csrInterface.vSew
+        csrInterface.vl << (csrInterface.vSew + decode.decodeResult(Decoder.crossWrite))
       )
     )
   }

--- a/v/src/VRF.scala
+++ b/v/src/VRF.scala
@@ -308,7 +308,7 @@ class VRF(val parameter: VRFParam) extends Module with SerializableModule[VRFPar
           record.bits.wWriteQueueClear := true.B
         }
       }
-      when(record.bits.stFinish && lsuWriteBufferClear && record.valid) {
+      when(record.bits.stFinish && (lsuWriteBufferClear || record.bits.st) && record.valid) {
         when(dataIndexWriteQueue) {
           record.bits.wWriteQueueClear
         } otherwise {

--- a/v/src/VRF.scala
+++ b/v/src/VRF.scala
@@ -289,6 +289,7 @@ class VRF(val parameter: VRFParam) extends Module with SerializableModule[VRFPar
     0.U(parameter.chainingSize.W)
   )
 
+  val writeOH: UInt = UIntToOH((write.bits.vd ## write.bits.offset)(4, 0))
   chainingRecord.zipWithIndex.foreach {
     case (record, i) =>
       val vsOffsetMask = record.bits.mul.andR ## record.bits.mul(1) ## record.bits.mul.orR
@@ -302,6 +303,7 @@ class VRF(val parameter: VRFParam) extends Module with SerializableModule[VRFPar
         // widen 类型的可能后一个先到,所以直接-1吧
         record.bits.offset := Mux(write.bits.offset === 0.U, write.bits.offset, write.bits.offset - 1.U)
         record.bits.vdOffset := vsOffsetMask & write.bits.vd
+        record.bits.elementMask := record.bits.elementMask | writeOH
       }
       when(ohCheck(lsuLastReport, record.bits.instIndex, parameter.chainingSize)) {
         when(record.bits.ls) {

--- a/v/src/VRF.scala
+++ b/v/src/VRF.scala
@@ -77,6 +77,8 @@ case class VRFParam(
 
   val vlWidth: Int = log2Ceil(vLen)
 
+  val elementSize: Int = vLen * 8 / datapathWidth / laneNumber
+
   /** Parameter for [[RegFile]] */
   def rfParam: RFParam = RFParam(rfDepth, width = ramWidth)
 }

--- a/v/src/laneStage/LaneExecutionBridge.scala
+++ b/v/src/laneStage/LaneExecutionBridge.scala
@@ -322,7 +322,7 @@ class LaneExecutionBridge(parameter: LaneParameter, isLastSlot: Boolean) extends
 
     // update `maskFormatResultForGroup`
     when(dataResponse.valid || updateMaskResult.get) {
-      maskFormatResultForGroup.foreach(_ := Mux(dataResponse.valid, maskFormatResultUpdate.get, 0.U))
+      maskFormatResultForGroup.foreach(_ := Mux(updateMaskResult.get, 0.U, maskFormatResultUpdate.get))
     }
     val normalReduceMask = Mux1H(
       state.vSew1H,

--- a/v/src/laneStage/LaneStage3.scala
+++ b/v/src/laneStage/LaneStage3.scala
@@ -63,8 +63,9 @@ class LaneStage3(parameter: LaneParameter, isLastSlot: Boolean) extends Module {
     )
   }
 
+  // Used to cut off back pressure forward
   val vrfWriteQueue: Queue[VRFWriteRequest] =
-    Module(new Queue(vrfWriteBundle, entries = 1, pipe = false, flow = false))
+    Module(new Queue(vrfWriteBundle, entries = 4, pipe = false, flow = false))
 
   /** Write queue ready or not need to write. */
   val vrfWriteReady: Bool = vrfWriteQueue.io.enq.ready || state.decodeResult(Decoder.sWrite)

--- a/v/src/lsu/LSU.scala
+++ b/v/src/lsu/LSU.scala
@@ -293,7 +293,7 @@ class LSU(param: LSUParam) extends Module {
   val storeEndLessThanLoadEnd: Bool = storeUnit.status.endAddress <= loadUnit.status.endAddress
 
   val addressOverlap: Bool = ((storeStartLargerThanLoadStart && storeStartLessThanLoadEnd) ||
-    (storeEndLargerThanLoadStart || storeEndLessThanLoadEnd)) && !(storeUnit.status.idle || loadUnit.status.idle)
+    (storeEndLargerThanLoadStart && storeEndLessThanLoadEnd)) && !(storeUnit.status.idle || loadUnit.status.idle)
   val stallLoad: Bool = !unitOrder && addressOverlap
   val stallStore: Bool = unitOrder && addressOverlap
 

--- a/v/src/package.scala
+++ b/v/src/package.scala
@@ -74,4 +74,108 @@ package object v {
       data(groupIndex * width + width - 1, groupIndex * width)
     })
   }
+
+  def calculateSegmentWriteMask(datapath: Int, laneNumber: Int, elementSizeForOneRegister: Int)
+                               (seg1H: UInt, mul1H: UInt, lastWriteOH: UInt): UInt = {
+    // not access for register -> na
+    val notAccessForRegister = Fill(elementSizeForOneRegister, true.B)
+    val writeOHGroup = cutUInt(lastWriteOH, elementSizeForOneRegister)
+    require(datapath==32 && laneNumber == 8, "If the parameters are modified, you need to modify them here.")
+    // writeOHGroup: d7 ## d6 ## d5 ## d4 ## d3 ## d2 ## d1 ## d0
+    // seg1: 2 reg group
+    //  mul0    na ## na ## na ## na ## na ## na ## d0 ## d0
+    //  mul1    na ## na ## na ## na ## d1 ## d0 ## d1 ## d0
+    //  mul2    d3 ## d2 ## d1 ## d0 ## d3 ## d2 ## d1 ## d0
+    // seg2: 3 reg group
+    //  mul0    na ## na ## na ## na ## na ## d0 ## d0 ## d0
+    //  mul1    na ## na ## d1 ## d0 ## d1 ## d0 ## d1 ## d0
+    // seg3: 4 reg group
+    //  mul0    na ## na ## na ## na ## d0 ## d0 ## d0 ## d0
+    //  mul1    d1 ## d0 ## d1 ## d0 ## d1 ## d0 ## d1 ## d0
+    // seg4: 5 reg group
+    //  mul0    na ## na ## na ## d0 ## d0 ## d0 ## d0 ## d0
+    // seg5: 6 reg group
+    //  mul0    na ## na ## d0 ## d0 ## d0 ## d0 ## d0 ## d0
+    // seg6: 7 reg group
+    //  mul0    na ## d0 ## d0 ## d0 ## d0 ## d0 ## d0 ## d0
+    // seg7: 8 reg group
+    //  mul0    d0 ## d0 ## d0 ## d0 ## d0 ## d0 ## d0 ## d0
+    val segMask0 = writeOHGroup(0)
+    val segMask1 = Mux(
+      ((mul1H(2) || mul1H(1)) && seg1H(1)) || (mul1H(1) && (seg1H(2) || seg1H(3))),
+      writeOHGroup(1),
+      writeOHGroup(0)
+    )
+    val segMask2: UInt = PriorityMux(
+      Seq(
+        mul1H(2) && seg1H(1),
+        mul1H(1) && seg1H(1),
+        true.B
+      ),
+      Seq(
+        writeOHGroup(2),
+        notAccessForRegister,
+        writeOHGroup(0)
+      )
+    )
+    val segMask3: UInt = PriorityMux(
+      Seq(
+        mul1H(2) && seg1H(1),
+        mul1H(1) && (seg1H(1) || seg1H(2) || seg1H(3)),
+        (mul1H(0) && seg1H(3)) || (seg1H(7) || seg1H(6) || seg1H(5) || seg1H(4)),
+        true.B
+      ),
+      Seq(
+        writeOHGroup(3),
+        writeOHGroup(1),
+        writeOHGroup(0),
+        notAccessForRegister
+      )
+    )
+    val segMask4: UInt = Mux(
+      (mul1H(2) && seg1H(1)) || (mul1H(1) && (seg1H(2) || seg1H(3))) ||
+        (seg1H(7) || seg1H(6) || seg1H(5) || seg1H(4)),
+      writeOHGroup(0),
+      notAccessForRegister
+    )
+    val segMask5: UInt = PriorityMux(
+      Seq(
+        (mul1H(2) && seg1H(1)) || (mul1H(1) && (seg1H(2) || seg1H(3))),
+        mul1H(0) && (seg1H(7) || seg1H(6) || seg1H(5)),
+        true.B
+      ),
+      Seq(
+        writeOHGroup(1),
+        writeOHGroup(0),
+        notAccessForRegister
+      )
+    )
+    val segMask6: UInt = PriorityMux(
+      Seq(
+        mul1H(2) && seg1H(1),
+        (mul1H(1) && seg1H(3)) || (mul1H(0) && (seg1H(7) || seg1H(6))),
+        true.B
+      ),
+      Seq(
+        writeOHGroup(2),
+        writeOHGroup(0),
+        notAccessForRegister
+      )
+    )
+    val segMask7: UInt = PriorityMux(
+      Seq(
+        mul1H(2) && seg1H(1),
+        mul1H(1) && seg1H(3),
+        mul1H(0) && seg1H(7),
+        true.B
+      ),
+      Seq(
+        writeOHGroup(3),
+        writeOHGroup(1),
+        writeOHGroup(0),
+        notAccessForRegister
+      )
+    )
+    segMask7 ## segMask6 ## segMask5 ## segMask4 ## segMask3 ## segMask2 ## segMask1 ## segMask0
+  }
 }

--- a/v/src/vrf/ChainingCheck.scala
+++ b/v/src/vrf/ChainingCheck.scala
@@ -28,8 +28,11 @@ class ChainingCheck(val parameter: VRFParam) extends Module {
   val raw: Bool = record.bits.vd.valid && (read.vs(4, 3) === record.bits.vd.bits) && hitElement
   val waw: Bool = readRecord.vd.valid && record.bits.vd.valid && readRecord.vd.bits === record.bits.vd.bits &&
     hitElement
-  val war: Bool = readRecord.vd.valid &&
-    (((vd === record.bits.vs1.bits) && record.bits.vs1.valid) || (vd === record.bits.vs2) ||
-      ((vd === record.bits.vd.bits) && record.bits.ma)) && hitElement
+  val warSource1: Bool = (vd === record.bits.vs1.bits) && record.bits.vs1.valid
+  // Only index type will read vs2
+  val warSource2: Bool = vd === record.bits.vs2 && (!record.bits.ls || record.bits.indexType)
+  // store or ma need read vd
+  val warVD: Bool = (vd === record.bits.vd.bits) && (record.bits.ma || record.bits.st)
+  val war: Bool = readRecord.vd.valid && (warSource1 || warSource2 || warVD) && hitElement
   checkResult := !((!older && (waw || raw || war)) && !sameInst && recordValid)
 }

--- a/v/src/vrf/ChainingCheck.scala
+++ b/v/src/vrf/ChainingCheck.scala
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2022 Jiuyang Liu <liu@jiuyang.me>
+
+package v
+import chisel3._
+import chisel3.util._
+
+
+/** read        : 发起读请求的相应信息
+ *  readRecord  : 发起读请求的指令的记录
+ *  record      : 要做比对的指令的记录
+ *              todo: 维护冲突表,免得每次都要算一次
+ */
+class ChainingCheck(val parameter: VRFParam) extends Module {
+  val read: VRFReadRequest = IO(Input(new VRFReadRequest(parameter.regNumBits, parameter.vrfOffsetBits, parameter.instructionIndexBits)))
+  val readRecord: VRFWriteReport = IO(Input(new VRFWriteReport(parameter)))
+  val record: ValidIO[VRFWriteReport] = IO(Flipped(Valid(new VRFWriteReport(parameter))))
+  val recordValid: Bool = IO(Input(Bool()))
+  val checkResult: Bool = IO(Output(Bool()))
+
+  // 先看新老
+  val older: Bool = instIndexL(read.instructionIndex, record.bits.instIndex)
+  val sameInst: Bool = read.instructionIndex === record.bits.instIndex
+  val readOH: UInt = UIntToOH((read.vs ## read.offset)(4, 0))
+  val hitElement: Bool = (readOH & record.bits.elementMask) === 0.U
+  val vd: UInt = readRecord.vd.bits
+
+  val raw: Bool = record.bits.vd.valid && (read.vs(4, 3) === record.bits.vd.bits) && hitElement
+  val waw: Bool = readRecord.vd.valid && record.bits.vd.valid && readRecord.vd.bits === record.bits.vd.bits &&
+    hitElement
+  val war: Bool = readRecord.vd.valid &&
+    (((vd === record.bits.vs1.bits) && record.bits.vs1.valid) || (vd === record.bits.vs2) ||
+      ((vd === record.bits.vd.bits) && record.bits.ma)) && hitElement
+  checkResult := !((!older && (waw || raw || war)) && !sameInst && recordValid)
+}

--- a/v/src/vrf/VRF.scala
+++ b/v/src/vrf/VRF.scala
@@ -215,7 +215,7 @@ class VRF(val parameter: VRFParam) extends Module with SerializableModule[VRFPar
         chainingRecord.zip(recordValidVec).zipWithIndex.map {
           case ((r, f), recordIndex) =>
             val checkModule = Module(new ChainingCheck(parameter))
-              .suggestName(s"ChainingCheck_read_port${i}_record${recordIndex}")
+              .suggestName(s"ChainingCheck_readPort${i}_record${recordIndex}")
             checkModule.read := v.bits
             checkModule.readRecord := readRecord
             checkModule.record := r

--- a/v/src/vrf/VRF.scala
+++ b/v/src/vrf/VRF.scala
@@ -160,6 +160,8 @@ class VRF(val parameter: VRFParam) extends Module with SerializableModule[VRFPar
   val lsuWriteBufferClear: Bool = IO(Input(Bool()))
   // todo: delete
   dontTouch(write)
+  val portFireCount: UInt = PopCount(VecInit(readRequests.map(_.fire) :+ write.fire))
+  dontTouch(portFireCount)
 
   val chainingRecord: Vec[ValidIO[VRFWriteReport]] = RegInit(
     VecInit(Seq.fill(parameter.chainingSize)(0.U.asTypeOf(Valid(new VRFWriteReport(parameter)))))


### PR DESCRIPTION
- [rtl] Remove cache fetch bubbles.
- [rtl] load store type instruction also need waiting for write buffer to be clear
- [rtl] Fix chaining between loadUnit and storeUnit.
- [rtl] Blocking mask-type followed by a write v0 case more precisely.
