### PR TITLE
[ci] fix checkout revision

### DIFF
--- a/.github/workflows/postpr.yml
+++ b/.github/workflows/postpr.yml
@@ -15,7 +15,7 @@ jobs:
     outputs:
       ci-tests: ${{ steps.ci-tests.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: sudo -E .github/setup-actions.sh
         env:
           AWS_CREDENTIALS: ${{secrets.AWS_CREDENTIALS}}
@@ -49,7 +49,7 @@ jobs:
     outputs:
       result: ${{ steps.ci-run.outputs.result }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: sudo -E .github/setup-actions.sh
         env:
           AWS_CREDENTIALS: ${{secrets.AWS_CREDENTIALS}}
@@ -115,7 +115,7 @@ jobs:
     runs-on: [self-hosted, linux]
     needs: report
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: master

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,8 +12,9 @@ jobs:
     outputs:
       ci-tests: ${{ steps.gen-matrix.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
       - run: sudo -E .github/setup-actions.sh
         env:
@@ -52,7 +53,9 @@ jobs:
     outputs:
       result: ${{ steps.ci-run.outputs.result }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - run: sudo -E .github/setup-actions.sh
         env:
           AWS_CREDENTIALS: ${{secrets.AWS_CREDENTIALS}}
@@ -131,7 +134,9 @@ jobs:
       matrix: ${{ fromJSON(needs.gen-fail-wave-matrix.outputs.retry_tasks) }}
     runs-on: [self-hosted, linux]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - run: sudo -E .github/setup-actions.sh
         env:
           AWS_CREDENTIALS: ${{secrets.AWS_CREDENTIALS}}
@@ -173,7 +178,7 @@ jobs:
     needs: [run-testcases]
     runs-on: [self-hosted, linux]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: ${{ github.head_ref }}


### PR DESCRIPTION
actions/checkout will use the "event" commit to checkout repository, which will lead to an unexpected issue that the "event" commit doesn't belongs to the repository.