### PR TITLE
[nix] add search ability for derivation in our t1 scope

### DIFF
--- a/nix/t1/default.nix
+++ b/nix/t1/default.nix
@@ -28,6 +28,8 @@ lib.makeScope newScope
   lib.genAttrs configNames (configName:
     # by using makeScope, callPackage can send the following attributes to package parameters
     lib.makeScope self.newScope (innerSelf: {
+      recurseForDerivations = true;
+
       config-name = configName;
       elaborate-config = ../../configs/${configName}.json;
 

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -45,9 +45,10 @@ let
       (lib.filterAttrs (_: fullPath: isCallableDir fullPath))
       # { "A": "/nix/store/.../"; B: "/nix/store/.../"; } => { "A": <derivation>; "B": <derivation>; }
       (lib.mapAttrs (_: fullPath: callPackage fullPath { }))
-    ];
+    ] // { recurseForDerivations = true; };
 
   self = {
+    recurseForDerivations = true;
     # nix build .#t1.rvv-testcases.<type>.<name>
     mlir = searchAndCallPackage ./mlir;
     intrinsic = searchAndCallPackage ./intrinsic;
@@ -88,7 +89,7 @@ let
         commonTests = getTestsFromFile ./codegen/common.txt { };
         fpTests = getTestsFromFile ./codegen/fp.txt { fp = true; };
       in
-      builtins.listToAttrs (commonTests ++ fpTests);
+      { recurseForDerivations = true; } // builtins.listToAttrs (commonTests ++ fpTests);
 
     all = runCommand "all-testcases"
       {


### PR DESCRIPTION
Set `recurseForDerivation = true` allow nix search to search inside attr set recursively. Now users can use `nix search .#t1 <regexp>` to search through all of the derivations we make.