### PR TITLE
Fix emulator hanging and refactor all env to use cmdline

### DIFF
--- a/ipemu/csrc/spdlog-ext.h
+++ b/ipemu/csrc/spdlog-ext.h
@@ -152,19 +152,19 @@ private:
 
     switch (log_type) {
     case LogType::Info:
-      file->info("{}", this->dump(-1));
+      if (file) file->info("{}", this->dump(-1));
       if (console) console->info("{}", this->dump(2));
       break;
     case LogType::Warn:
-      file->warn("{}", this->dump(-1));
+      if (file) file->warn("{}", this->dump(-1));
       if (console) console->warn("{}", this->dump(2));
       break;
     case LogType::Trace:
-      file->trace("{}", this->dump(-1));
+      if (file) file->trace("{}", this->dump(-1));
       if (console) console->trace("{}", this->dump(2));
       break;
     case LogType::Fatal:
-      file->critical("{}", this->dump(-1));
+      if (file) file->critical("{}", this->dump(-1));
       if (console) console->critical("{}", this->dump(2));
       spdlog::shutdown();
 
@@ -173,7 +173,7 @@ private:
   }
 
 public:
-  JsonLogger();
+  JsonLogger(bool no_logging, bool no_file_logging, bool no_console_logging, std::optional<std::string> log_path);
   ~JsonLogger() = default;
 
   inline JsonLogger operator()(const char *n) {

--- a/ipemu/csrc/vbridge_impl.cc
+++ b/ipemu/csrc/vbridge_impl.cc
@@ -21,11 +21,8 @@ inline bool is_pow2(uint32_t n) { return n && !(n & (n - 1)); }
 
 void VBridgeImpl::timeoutCheck() {
   getCoverage();
-  if (get_t() > timeout + last_commit_time) {
-    Log("VBridgeImplTimeoutCheck")
-        .with("last_commit", last_commit_time)
-        .fatal("Simulation timeout");
-  }
+  CHECK_LE(get_t(), timeout + last_commit_time,
+           fmt::format("Simulation timeout, last_commit: {}", last_commit_time));
 }
 
 void VBridgeImpl::dpiInitCosim() {
@@ -354,9 +351,7 @@ std::optional<SpikeEvent> VBridgeImpl::spike_step() {
     case PC_SERIALIZE_AFTER:
       break;
     default:
-      Log("SpikeStep")
-          .with("pc", fmt::format("{:08x}", pc))
-          .fatal("invalid pc");
+      FATAL(fmt::format("SpikeStep: invalid pc: {:08X}", pc));
     }
   }
 

--- a/ipemu/csrc/vbridge_impl.cc
+++ b/ipemu/csrc/vbridge_impl.cc
@@ -736,7 +736,7 @@ void VBridgeImpl::record_rf_accesses(const VrfWritePeek &rf_write) {
     if (se_vrf_write == nullptr) {
       Log("RecordRFAccess")
           .with("index", idx)
-          .warn("rtl detect vrf write which cannot find se, maybe from "
+          .info("rtl detect vrf write which cannot find se, maybe from "
                 "committed load insn");
     } else if (!se_vrf_write->is_load) {
       Log("RecordRFAccess")

--- a/ipemu/csrc/vbridge_impl.cc
+++ b/ipemu/csrc/vbridge_impl.cc
@@ -213,7 +213,13 @@ static VBridgeImpl vbridgeImplFromArgs() {
   }
 
   args::ArgumentParser parser("emulator for t1");
-  args::ValueFlag<std::string> config_path(parser, "config path", "", {"config"}, args::Options::Required);
+
+  args::Flag no_logging(parser, "no_logging", "Disable all logging utilities.", { "no-logging" });
+  args::Flag no_file_logging(parser, "no_file_logging", "Disable file logging utilities.", { "no-file-logging" });
+  args::Flag no_console_logging(parser, "no_console_logging", "Disable console logging utilities.", { "no-console-logging" });
+  args::ValueFlag<std::optional<std::string>> log_path(parser, "log path", "Path to store logging file", {"log-path"});
+
+  args::ValueFlag<std::string> config_path(parser, "config path", "", {"config"});
   args::ValueFlag<std::string> bin_path(parser, "elf path", "", {"elf"}, args::Options::Required);
   args::ValueFlag<std::string> wave_path(parser, "wave path", "", {"wave"}, args::Options::Required);
   args::ValueFlag<std::optional<std::string>> perf_path(parser, "perf path", "", {"perf"});
@@ -232,6 +238,8 @@ static VBridgeImpl vbridgeImplFromArgs() {
     std::cerr << e.what() << std::endl << parser;
     std::exit(1);
   }
+
+  Log = JsonLogger(no_logging.Get(), no_file_logging.Get(), no_console_logging.Get(), log_path.Get());
 
   CosimConfig cosim_config {
     .bin_path = bin_path.Get(),


### PR DESCRIPTION
This PR fix emulator hanging when using --no-logging. When we disable logging, cosim timeout check will fail to bail out because the error bailing functionality is relied on the logging utils.
