### PR TITLE
split mill build stage

### DIFF
--- a/nix/pkgs/mill-builder.nix
+++ b/nix/pkgs/mill-builder.nix
@@ -40,8 +40,7 @@ let
     outputHashMode = "recursive";
     outputHash = millDepsHash;
 
-    dontShrink = true;
-    dontPatchELF = true;
+    dontFixup = true;
 
     passthru.setupHook = makeSetupHook
       {
@@ -50,14 +49,14 @@ let
       }
       (writeText "mill-setup-hook" ''
         setupMillCache() {
-          local tmpdir=$(mktemp -d)
-          export JAVA_OPTS="$JAVA_OPTS -Duser.home=$tmpdir"
+          export MILL_HOME=$TMPDIR/mill-cache
+          export JAVA_OPTS="$JAVA_OPTS -Duser.home=$MILL_HOME"
 
-          mkdir -p "$tmpdir"/.cache
+          mkdir -p "$MILL_HOME"/.cache
 
-          cp -r "${self}"/.cache/coursier "$tmpdir"/.cache/
+          cp -r "${self}"/.cache/coursier "$MILL_HOME"/.cache/
 
-          echo "JAVA HOME dir set to $tmpdir"
+          echo "JAVA HOME dir set to $MILL_HOME"
         }
 
         postUnpackHooks+=(setupMillCache)

--- a/nix/t1/configgen.nix
+++ b/nix/t1/configgen.nix
@@ -1,10 +1,11 @@
 { lib
 , stdenvNoCC
-, fetchMillDeps
 , mill
 , makeWrapper
 , jre
 , submodules
+
+, _t1CompileCache
 }:
 
 stdenvNoCC.mkDerivation rec {
@@ -20,17 +21,8 @@ stdenvNoCC.mkDerivation rec {
     ];
   }).outPath;
 
-  passthru.millDeps = fetchMillDeps {
-    inherit name;
-    src = (with lib.fileset; toSource {
-      root = ./../..;
-      fileset = unions [
-        ./../../build.sc
-        ./../../common.sc
-      ];
-    }).outPath;
-    millDepsHash = "sha256-3ueeJddftivvV5jQtg58sKKwXv0T2vkGxblenYFjrso=";
-    nativeBuildInputs = [ submodules.setupHook ];
+  passthru = {
+    inherit (_t1CompileCache) millDeps;
   };
 
   shellHook = ''
@@ -42,11 +34,12 @@ stdenvNoCC.mkDerivation rec {
 
     makeWrapper
     passthru.millDeps.setupHook
+    _t1CompileCache.setupHook
     submodules.setupHook
   ];
 
   buildPhase = ''
-    mill -i 'configgen.assembly'
+    mill -i --jobs 0 'configgen.assembly'
   '';
 
   installPhase = ''

--- a/nix/t1/default.nix
+++ b/nix/t1/default.nix
@@ -10,16 +10,19 @@ let
   # We need to bring submodules and configgen out of scope. Using them in scope to generate the package attribute set
   # will lead to infinite recursion.
   submodules = callPackage ./submodules.nix { };
-  configgen = callPackage ./configgen.nix { inherit submodules; };
+
+  _t1CompileCache = callPackage ./t1CompileCache.nix { inherit submodules; };
+
+  configgen = callPackage ./configgen.nix { inherit submodules _t1CompileCache; };
   allConfigs = builtins.fromJSON (builtins.readFile "${configgen}/share/all-supported-configs.json");
 in
 
 lib.makeScope newScope
   (self:
   {
-    elaborator = self.callPackage ./elaborator.nix { };
+    elaborator = self.callPackage ./elaborator.nix { inherit _t1CompileCache; };
 
-    inherit submodules configgen;
+    inherit submodules configgen _t1CompileCache;
 
     riscv-opcodes-src = self.submodules.sources.riscv-opcodes.src;
 

--- a/nix/t1/elaborator.nix
+++ b/nix/t1/elaborator.nix
@@ -10,6 +10,8 @@
 
 , nvfetcher
 , submodules
+
+, _t1CompileCache
 }:
 
 let
@@ -32,17 +34,8 @@ let
       ];
     }).outPath;
 
-    passthru.millDeps = fetchMillDeps {
-      inherit name;
-      src = (with lib.fileset; toSource {
-        root = ./../..;
-        fileset = unions [
-          ./../../build.sc
-          ./../../common.sc
-        ];
-      }).outPath;
-      millDepsHash = "sha256-3ueeJddftivvV5jQtg58sKKwXv0T2vkGxblenYFjrso=";
-      nativeBuildInputs = [ submodules.setupHook ];
+    passthru = {
+      inherit (_t1CompileCache) millDeps;
     };
 
     passthru.editable = self.overrideAttrs (_: {
@@ -64,6 +57,7 @@ let
 
       nvfetcher
       submodules.setupHook
+      _t1CompileCache.setupHook
     ];
 
     buildPhase = ''

--- a/nix/t1/t1CompileCache.nix
+++ b/nix/t1/t1CompileCache.nix
@@ -1,0 +1,101 @@
+{ lib
+, fetchMillDeps
+, stdenvNoCC
+, mill
+, makeSetupHook
+, writeText
+
+, submodules
+}:
+
+let
+  self = stdenvNoCC.mkDerivation rec {
+    name = "t1-compile-cache";
+    meta.description = "T1 mill compile cache. Internal build stage, don't use it.";
+
+    src = (with lib.fileset; toSource {
+      root = ./../..;
+      fileset = unions [
+        ./../../build.sc
+        ./../../common.sc
+        ./../../t1
+        ./../../subsystem
+        ./../../rocket
+        ./../../emuhelper
+        ./../../ipemu/src
+        ./../../subsystememu
+        ./../../fpga
+        ./../../elaborator
+      ];
+    }).outPath;
+
+    passthru = {
+      millDeps = fetchMillDeps {
+        inherit name;
+        src = (with lib.fileset; toSource {
+          root = ./../..;
+          fileset = unions [
+            ./../../build.sc
+            ./../../common.sc
+          ];
+        }).outPath;
+        millDepsHash = "sha256-3ueeJddftivvV5jQtg58sKKwXv0T2vkGxblenYFjrso=";
+        nativeBuildInputs = [ submodules.setupHook ];
+      };
+
+      # Automatically copy and setup mill build output directory in this derivation into caller's source directory
+      setupHook = makeSetupHook
+        {
+          name = "mill-output-cache-hook";
+          propagatedBuildInputs = [ mill ];
+        }
+        (writeText "mill-output-cache-setup-hook" ''
+          setupMillOut() {
+            echo "Running setupHook from ${self.name}"
+
+            mkdir -p $MILL_HOME/.mill/ammonite/
+            cp ${self}/rt-*.jar $MILL_HOME/.mill/ammonite/
+
+            cp -r ${self}/build-output "$sourceRoot"/out
+            # Make sure the out directory is writable
+            chmod -R u+w -- "$sourceRoot"/out
+          }
+
+          postUnpackHooks+=(setupMillOut)
+        '');
+    };
+
+    nativeBuildInputs = [
+      mill
+      submodules.setupHook
+      passthru.millDeps.setupHook
+    ];
+
+    shellHook = ''
+      setupSubmodules
+    '';
+
+    buildPhase = ''
+      runHook preBuild
+
+      # --jobs 0 use all core
+      mill -i --jobs 0 __.compile
+
+      runHook postBuild
+    '';
+
+    dontFixup = true;
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p $out
+      mv out $out/build-output
+
+      cp $MILL_HOME/.mill/ammonite/rt-*.jar $out/
+
+      runHook postInstall
+    '';
+  };
+in
+self


### PR DESCRIPTION
This PR add a breakpoint to the elaborator build process: a new derivation `_t1BuildCache`. This derivation will compile all the modules simultaneously and use mill output as nix output. So that for configgen and elaborator module, they can share these build cache, remove redundant compile steps and speed up the whole RTL compile process.