### PR TITLE
[nix] expose T1 testcases to outside

### DIFF
--- a/nix/t1/default.nix
+++ b/nix/t1/default.nix
@@ -41,6 +41,8 @@ lib.makeScope newScope
       mkAsmCase = self.callPackage ./testcases/make-asm-case.nix { stdenv = rv32-stdenv; };
       mkCodegenCase = self.callPackage ./testcases/make-codegen-case.nix { stdenv = rv32-stdenv; };
     };
+    makeTestCase = { xLen, vLen }: self.callPackage ../../tests { inherit xLen vLen; };
+
   } //
   lib.genAttrs allConfigs (configName:
     # by using makeScope, callPackage can send the following attributes to package parameters
@@ -57,7 +59,7 @@ lib.makeScope newScope
 
       _elaborateConfig = with builtins; fromJSON (readFile "${elaborate-config}/config.json");
 
-      cases = self.callPackage ../../tests { inherit (_elaborateConfig.parameter) xLen vLen; };
+      cases = self.makeTestCase { inherit (_elaborateConfig.parameter) xLen vLen; };
 
       cases-x86 =
         if system == "x86-64-linux"


### PR DESCRIPTION
This change allow user to build testcases with their configured xLen vLen from other project,
instead of building the whole configgen and t1 source to their project.

Signed-off-by: Avimitin <dev@avimit.in>
