### PR TITLE
[ci] fix failing CI for PR from fork repository

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -183,7 +183,10 @@ jobs:
 
   report:
     name: "Report CI result"
-    if: ${{ !cancelled() }}
+    # Don't run report when:
+    #   - user cancel ( we don't need report at this case )
+    #   - PR from outside repository ( we don't have permission to push commit into fork repository )
+    if: ${{ !cancelled() && github.event.pull_request.head.repo.full_name == github.repository }}
     needs: [run-testcases]
     runs-on: [self-hosted, linux, nixos]
     steps:


### PR DESCRIPTION
Allow users outside of chipsalliance to be able to make PR and pass workflow.