### PR TITLE
[nix] bump to firtool 1.68, marking input clock explicit

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1705309234,
-        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1708807242,
-        "narHash": "sha256-sRTRkhMD4delO/hPxxi+XwLqPn8BuUq6nnj4JqLwOu0=",
+        "lastModified": 1710806803,
+        "narHash": "sha256-qrxvLS888pNJFwJdK+hf1wpRCSQcqA6W5+Ox202NDa0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "73de017ef2d18a04ac4bfd0c02650007ccb31c2a",
+        "rev": "b06025f1533a1e07b6db3e75151caa155d1c7eb3",
         "type": "github"
       },
       "original": {

--- a/subsystem/src/Subsystem.scala
+++ b/subsystem/src/Subsystem.scala
@@ -428,14 +428,21 @@ class T1Subsystem(implicit p: Parameters)
   val vectorPorts = InModuleBody {
     vectorMemoryNodes.zipWithIndex.map { case (n, i) => n.makeIOs()(ValName(s"vectorChannel$i")) }
   }
-  val clock = InModuleBody{ clockSource.makeIOs() }
+  val clock = InModuleBody {
+    val clockInput = clockSource.out.map(_._1).head
+    val clock = IO(Input(Clock()))
+    val reset = IO(Input(Bool()))
+    clockInput.clock := clock
+    clockInput.reset := reset
+    clockInput
+  }
 }
 
 class T1SubsystemModuleImp[+L <: T1Subsystem](_outer: L)
     extends BareSubsystemModuleImp(_outer)
     with HasHierarchicalElementsRootContextModuleImp {
-  childClock := outer.clock.head.clock
-  childReset := outer.clock.head.reset.asBool
+  childClock := outer.clock.clock
+  childReset := outer.clock.reset
 
   lazy val outer = _outer
   // IntSyncCrossingSource requires implcit clock


### PR DESCRIPTION
Bump to nixpkgs master branch since we can depends on our own S3 cache.
This PR will also bump circt to 1.66.0