### PR TITLE
[build system] remove default t1package.jar target

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -297,5 +297,4 @@ object t1package extends ScalaModule {
   def scalaVersion = T(v.scala)
   def moduleDeps = super.moduleDeps ++ Seq(t1, ipemu, subsystem, panamaconverter)
   override def sourceJar: T[PathRef] = T(Jvm.createJar(T.traverse(transitiveModuleDeps)(dep => T.sequence(Seq(dep.allSources, dep.resources, dep.compileResources)))().flatten.flatten.map(_.path).filter(os.exists), manifest()))
-  override def jar: T[PathRef] = T(Jvm.createJar(upstreamAssemblyClasspath().map(_.path).filter(os.exists), manifest()))
 }

--- a/nix/t1/t1.nix
+++ b/nix/t1/t1.nix
@@ -77,7 +77,6 @@ let
       mill -i '__.assembly'
 
       mill -i t1package.sourceJar
-      mill -i t1package.jar
     '';
 
     installPhase = ''
@@ -85,13 +84,15 @@ let
 
       strip-nondeterminism out/elaborator/assembly.dest/out.jar
       strip-nondeterminism out/configgen/assembly.dest/out.jar
+      strip-nondeterminism out/t1package/assembly.dest/out.jar
+      strip-nondeterminism out/t1package/sourceJar.dest/out.jar
 
       mv out/configgen/assembly.dest/out.jar $out/share/java/configgen.jar
       mv out/elaborator/assembly.dest/out.jar $out/share/java/elaborator.jar
 
       mkdir -p $t1package/share/java
       mv out/t1package/sourceJar.dest/out.jar $t1package/share/java/t1package-sources.jar
-      mv out/t1package/jar.dest/out.jar $t1package/share/java/t1package.jar
+      mv out/t1package/assembly.dest/out.jar $t1package/share/java/t1package.jar
 
       mkdir -p $configgen/bin $elaborator/bin
       makeWrapper ${jdk21}/bin/java $configgen/bin/configgen --add-flags "-jar $out/share/java/configgen.jar"


### PR DESCRIPTION
Use t1package.assembly to get correct dependencies bundled fat jar package.