### PR TITLE
[ci] update MEM:32 label to BIGRAM

### DIFF
--- a/.github/workflows/daily-regression.yml
+++ b/.github/workflows/daily-regression.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   gen-matrix:
     name: "Generate test matrix"
-    runs-on: [self-hosted, linux, nixos, "MEM:32"]
+    runs-on: [self-hosted, linux, nixos, BIGRAM]
     env:
       RUNNERS: 70
     outputs:
@@ -52,7 +52,7 @@ jobs:
 
   gen-perf-matrix:
     name: "Generate test matrix for perf cases"
-    runs-on: [self-hosted, linux, nixos, "MEM:32"]
+    runs-on: [self-hosted, linux, nixos, BIGRAM]
     env:
       RUNNERS: 70
     outputs:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -51,7 +51,7 @@ jobs:
   gen-matrix:
     name: "Prepare for running testcases"
     needs: [build-emulators]
-    runs-on: [self-hosted, linux, nixos, "MEM:32"]
+    runs-on: [self-hosted, linux, nixos, BIGRAM]
     env:
       RUNNERS: 70
     outputs:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -32,7 +32,7 @@ jobs:
   build-emulators:
     name: "Build Emulators"
     needs: [gen-test-plan]
-    runs-on: [self-hosted, linux, nixos]
+    runs-on: [self-hosted, linux, nixos, BIGRAM]
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.gen-test-plan.outputs.testplan) }}


### PR DESCRIPTION
We should use label to describe machines, instead of specify machine.
This can help us change the label meaning internally, also make our CI infra scalable.

Signed-off-by: Avimitin <dev@avimit.in>