### PR TITLE
[nix] add pyEnv into propagatedBuildInputs

### DIFF
--- a/nix/pkgs/add-determinism/default.nix
+++ b/nix/pkgs/add-determinism/default.nix
@@ -37,6 +37,8 @@ rustPlatform.buildRustPackage {
     pkg-config
   ];
 
+  propagatedBuildInputs = [ pyEnv ];
+
   buildInputs = [
     zlib
   ];


### PR DESCRIPTION
This allow nix automatically load required PYTHONPATH into build environment.