### PR TITLE
refactor ipemu probes

### DIFF
--- a/ipemu/src/TestBench.scala
+++ b/ipemu/src/TestBench.scala
@@ -190,32 +190,24 @@ class TestBench(generator: SerializableModuleGenerator[T1, T1Parameter])
 
   // Events for difftest and performance modeling
 
-  val laneProbes = dut.io.laneProbes.zipWithIndex.map {
-    case (p, idx) =>
-      val wire = Wire(p.cloneType).suggestName(s"lane${idx}Probe")
-      wire := probe.read(p)
-      wire
+  // Probes
+  val laneProbes = t1Probe.laneProbes.zipWithIndex.map {
+    case (lane, i) => lane.suggestName(s"lane${i}Probe")
   }
 
-  val lsuProbe = probe.read(dut.io.lsuProbe).suggestName("lsuProbe")
+  val lsuProbe = t1Probe.lsuProbe.suggestName("lsuProbe")
 
   val storeUnitProbe = lsuProbe.storeUnitProbe.suggestName("storeUnitProbe")
 
   val otherUnitProbe = lsuProbe.otherUnitProbe.suggestName("otherUnitProbe")
 
-  val laneVrfProbes = dut.io.laneVrfProbes.zipWithIndex.map {
-    case (p, idx) =>
-      val wire = Wire(p.cloneType).suggestName(s"lane${idx}VrfProbe")
-      wire := probe.read(p)
-      wire
-  }
-
   // vrf write
-  laneVrfProbes.zipWithIndex.foreach {
+  laneProbes.zipWithIndex.foreach {
     case (lane, i) =>
-      when(lane.valid)(
+      val vrf = lane.vrfProbe.suggestName(s"lane${i}VrfProbe")
+      when(vrf.valid)(
         printf(
-          cf"""{"event":"VrfWrite","issue_idx":${lane.requestInstruction},"vd":${lane.requestVd},"offset":${lane.requestOffset},"mask":"${lane.requestMask}%x","data":"${lane.requestData}%x","lane":$i,"cycle":${simulationTime}}\n"""
+          cf"""{"event":"VrfWrite","issue_idx":${vrf.requestInstruction},"vd":${vrf.requestVd},"offset":${vrf.requestOffset},"mask":"${vrf.requestMask}%x","data":"${vrf.requestData}%x","lane":$i,"cycle":${simulationTime}}\n"""
         )
       )
   }

--- a/t1/src/T1.scala
+++ b/t1/src/T1.scala
@@ -292,18 +292,18 @@ case class T1Parameter(
   def adderParam: LaneAdderParam = LaneAdderParam(datapathWidth, 0)
 }
 
-class T1Probe(param: T1Parameter) extends Bundle {
-  val instructionCounter: UInt = UInt(param.instructionIndexBits.W)
+class T1Probe(parameter: T1Parameter) extends Bundle {
+  val instructionCounter: UInt = UInt(parameter.instructionIndexBits.W)
   val instructionIssue: Bool = Bool()
-  val issueTag: UInt = UInt(param.instructionIndexBits.W)
+  val issueTag: UInt = UInt(parameter.instructionIndexBits.W)
   val retireValid: Bool = Bool()
   // write queue enq for mask unit
-  val writeQueueEnq: ValidIO[UInt] = Valid(UInt(param.instructionIndexBits.W))
-  val writeQueueEnqMask: UInt = UInt((param.datapathWidth / 8).W)
+  val writeQueueEnq: ValidIO[UInt] = Valid(UInt(parameter.instructionIndexBits.W))
+  val writeQueueEnqMask: UInt = UInt((parameter.datapathWidth / 8).W)
   // mask unit instruction valid
-  val instructionValid: UInt = UInt((param.chainingSize * 2).W)
+  val instructionValid: UInt = UInt((parameter.chainingSize * 2).W)
   // instruction index for check rd
-  val responseCounter: UInt = UInt(param.instructionIndexBits.W)
+  val responseCounter: UInt = UInt(parameter.instructionIndexBits.W)
 }
 
 class T1Interface(parameter: T1Parameter) extends Record {
@@ -332,10 +332,10 @@ class T1Interface(parameter: T1Parameter) extends Record {
       "t1Probe" -> Output(Probe(new T1Probe(parameter))),
     ) ++
       Seq.tabulate(parameter.laneNumber)(
-        i => s"lane${i}Probe" -> Output(Probe(new LaneProbe(parameter.chainingSize, parameter.instructionIndexBits)))
+        i => s"lane${i}Probe" -> Output(Probe(new LaneProbe(parameter.laneParam)))
       ) ++
       Seq.tabulate(parameter.laneNumber)(
-        i => s"lane${i}VrfProbe" -> Output(Probe(new VRFProbe(parameter.laneParam.vrfParam.regNumBits, parameter.laneParam.vrfOffsetBits, parameter.laneParam.instructionIndexBits, parameter.laneParam.datapathWidth)))
+        i => s"lane${i}VrfProbe" -> Output(Probe(new VRFProbe(parameter.laneParam.vrfParam)))
       )
   )
 }

--- a/t1/src/lsu/LSU.scala
+++ b/t1/src/lsu/LSU.scala
@@ -246,9 +246,9 @@ class LSU(param: LSUParameter) extends Module {
   )
 
   @public
-  val _probe = IO(Output(Probe(new LSUProbe(param))))
+  val lsuProbe = IO(Output(Probe(new LSUProbe(param))))
   val probeWire = Wire(new LSUProbe(param))
-  define(_probe, ProbeValue(probeWire))
+  define(lsuProbe, ProbeValue(probeWire))
 
   // read vrf
   val otherTryReadVrf: UInt = Mux(otherUnit.vrfReadDataPorts.valid, otherUnit.status.targetLane, 0.U)

--- a/t1/src/vrf/VRF.scala
+++ b/t1/src/vrf/VRF.scala
@@ -564,9 +564,9 @@ class VRF(val parameter: VRFParam) extends Module with SerializableModule[VRFPar
   * Probe
   */
   @public
-  val probe = IO(Output(Probe(new VRFProbe(parameter))))
+  val vrfProbe = IO(Output(Probe(new VRFProbe(parameter))))
   val probeWire = Wire(new VRFProbe(parameter))
-  define(probe, ProbeValue(probeWire))
+  define(vrfProbe, ProbeValue(probeWire))
 
   probeWire.valid := writePipe.valid
   probeWire.requestVd := writePipe.bits.vd

--- a/t1/src/vrf/VRF.scala
+++ b/t1/src/vrf/VRF.scala
@@ -106,13 +106,13 @@ case class VRFParam(
   val vrfReadLatency = 2
 }
 
-class VRFProbe(regNumBits: Int, offsetBits: Int, instructionIndexSize: Int, dataPathWidth: Int) extends Bundle {
+class VRFProbe(parameter: VRFParam) extends Bundle {
   val valid: Bool = Bool()
-  val requestVd: UInt = UInt(regNumBits.W)
-  val requestOffset: UInt = UInt(offsetBits.W)
-  val requestMask: UInt = UInt((dataPathWidth / 8).W)
-  val requestData: UInt = UInt(dataPathWidth.W)
-  val requestInstruction: UInt = UInt(instructionIndexSize.W)
+  val requestVd: UInt = UInt(parameter.regNumBits.W)
+  val requestOffset: UInt = UInt(parameter.vrfOffsetBits.W)
+  val requestMask: UInt = UInt((parameter.datapathWidth / 8).W)
+  val requestData: UInt = UInt(parameter.datapathWidth.W)
+  val requestInstruction: UInt = UInt(parameter.instructionIndexBits.W)
 }
 
 /** Vector Register File.
@@ -564,8 +564,8 @@ class VRF(val parameter: VRFParam) extends Module with SerializableModule[VRFPar
   * Probe
   */
   @public
-  val probe = IO(Output(Probe(new VRFProbe(parameter.regNumBits, parameter.vrfOffsetBits, parameter.instructionIndexBits, parameter.datapathWidth))))
-  val probeWire = Wire(new VRFProbe(parameter.regNumBits, parameter.vrfOffsetBits, parameter.instructionIndexBits, parameter.datapathWidth))
+  val probe = IO(Output(Probe(new VRFProbe(parameter))))
+  val probeWire = Wire(new VRFProbe(parameter))
   define(probe, ProbeValue(probeWire))
 
   probeWire.valid := writePipe.valid


### PR DESCRIPTION
- [x] refactor probe signatures to improve readability
- [x] refactor to an single Probe to avoid using Record on the [[T1Interface]].
