### PR TITLE
Fix spike trap

### DIFF
--- a/difftest/spike_interfaces/spike_interfaces.cc
+++ b/difftest/spike_interfaces/spike_interfaces.cc
@@ -142,6 +142,7 @@ reg_t proc_func(spike_processor_t *proc) {
     //          << ", tinst=" << std::setw(8) << std::hex << trap.get_tinst()
     //          << ")" << std::endl;
     //throw trap;
+    proc->is_exception = true;
     res = state->pc;
   } 
 
@@ -156,9 +157,13 @@ reg_t proc_get_insn(spike_processor_t *proc) {
 }
 
 reg_t proc_get_insn_with_pc(spike_processor_t *proc, reg_t pc) {
-  auto mmu = proc->p->get_mmu();
-  auto fetch = mmu->load_insn(pc);
-  return fetch.insn.bits();
+  try {
+    auto mmu = proc->p->get_mmu();
+    auto fetch = mmu->load_insn(pc);
+    return fetch.insn.bits();
+  } catch(...) {
+    return 0;
+  }
 }
 
 uint8_t proc_get_vreg_data(spike_processor_t *proc, uint32_t vreg_idx,
@@ -181,8 +186,12 @@ uint32_t proc_get_rs1(spike_processor_t *proc) {
 }
 
 uint32_t proc_get_rs1_with_pc(spike_processor_t *proc, reg_t pc) {
-  auto fetch = proc->p->get_mmu()->load_insn(pc);
-  return (uint32_t)fetch.insn.rs1();
+  try{
+    auto fetch = proc->p->get_mmu()->load_insn(pc);
+    return (uint32_t)fetch.insn.rs1();
+  } catch(...) {
+    return 0;
+  }
 }
 
 uint32_t proc_get_rs2(spike_processor_t *proc) {
@@ -192,8 +201,12 @@ uint32_t proc_get_rs2(spike_processor_t *proc) {
 }
 
 uint32_t proc_get_rs2_with_pc(spike_processor_t *proc, reg_t pc) {
-  auto fetch = proc->p->get_mmu()->load_insn(pc);
-  return (uint32_t)fetch.insn.rs2();
+  try{
+    auto fetch = proc->p->get_mmu()->load_insn(pc);
+    return (uint32_t)fetch.insn.rs2();
+  } catch(...) {
+    return 0;
+  }
 }
 
 uint32_t proc_get_rd(spike_processor_t *proc) {
@@ -203,8 +216,12 @@ uint32_t proc_get_rd(spike_processor_t *proc) {
 }
 
 uint32_t proc_get_rd_with_pc(spike_processor_t *proc, reg_t pc) {
-  auto fetch = proc->p->get_mmu()->load_insn(pc);
-  return fetch.insn.rd();
+  try {
+    auto fetch = proc->p->get_mmu()->load_insn(pc);
+    return fetch.insn.rd();
+  } catch(...) {
+    return 0;
+  }
 }
 
 uint64_t proc_vu_get_vtype(spike_processor_t *proc) {

--- a/difftest/spike_interfaces/spike_interfaces.cc
+++ b/difftest/spike_interfaces/spike_interfaces.cc
@@ -56,6 +56,13 @@ const char *proc_disassemble(spike_processor_t *proc) {
   return strdup(disasm->disassemble(fetch.insn).c_str());
 }
 
+const char *proc_disassemble_with_pc(spike_processor_t *proc, reg_t pc) {
+  auto mmu = proc->p->get_mmu();
+  auto disasm = proc->p->get_disassembler();
+  auto fetch = mmu->load_insn(pc);
+  return strdup(disasm->disassemble(fetch.insn).c_str());
+}
+
 spike_processor_t *spike_get_proc(spike_t *spike) {
   return new spike_processor_t{spike->s->get_proc()};
 }
@@ -76,7 +83,7 @@ reg_t proc_func(spike_processor_t *proc) {
     fetch = mmu->load_insn(pc);
     res = fetch.func(proc->p, fetch.insn, pc);
   } catch (trap_t &trap) {
-    printf("catch exception\n");
+    //printf("catch exception\n");
     unsigned max_xlen = proc->p->get_const_xlen();
     state_t* state = proc->p->get_state();
     reg_t hsdeleg = (state->prv <= PRV_S) ? state->medeleg->read() : 0;
@@ -148,6 +155,12 @@ reg_t proc_get_insn(spike_processor_t *proc) {
   return fetch.insn.bits();
 }
 
+reg_t proc_get_insn_with_pc(spike_processor_t *proc, reg_t pc) {
+  auto mmu = proc->p->get_mmu();
+  auto fetch = mmu->load_insn(pc);
+  return fetch.insn.bits();
+}
+
 uint8_t proc_get_vreg_data(spike_processor_t *proc, uint32_t vreg_idx,
                            uint32_t vreg_offset) {
   return proc->p->VU.elt<uint8_t>(vreg_idx, vreg_offset);
@@ -167,14 +180,29 @@ uint32_t proc_get_rs1(spike_processor_t *proc) {
   return (uint32_t)fetch.insn.rs1();
 }
 
+uint32_t proc_get_rs1_with_pc(spike_processor_t *proc, reg_t pc) {
+  auto fetch = proc->p->get_mmu()->load_insn(pc);
+  return (uint32_t)fetch.insn.rs1();
+}
+
 uint32_t proc_get_rs2(spike_processor_t *proc) {
   auto pc = proc->p->get_state()->pc;
   auto fetch = proc->p->get_mmu()->load_insn(pc);
   return (uint32_t)fetch.insn.rs2();
 }
 
+uint32_t proc_get_rs2_with_pc(spike_processor_t *proc, reg_t pc) {
+  auto fetch = proc->p->get_mmu()->load_insn(pc);
+  return (uint32_t)fetch.insn.rs2();
+}
+
 uint32_t proc_get_rd(spike_processor_t *proc) {
   auto pc = proc->p->get_state()->pc;
+  auto fetch = proc->p->get_mmu()->load_insn(pc);
+  return fetch.insn.rd();
+}
+
+uint32_t proc_get_rd_with_pc(spike_processor_t *proc, reg_t pc) {
   auto fetch = proc->p->get_mmu()->load_insn(pc);
   return fetch.insn.rd();
 }

--- a/difftest/spike_interfaces/spike_interfaces.h
+++ b/difftest/spike_interfaces/spike_interfaces.h
@@ -61,6 +61,7 @@ struct spike_t {
 };
 struct spike_processor_t {
   processor_t *p;
+  bool is_exception;
 };
 struct spike_state_t {
   state_t *s;

--- a/difftest/spike_interfaces/spike_interfaces_c.h
+++ b/difftest/spike_interfaces/spike_interfaces_c.h
@@ -17,17 +17,22 @@ void spike_register_callback(void *ffi_target, ffi_callback callback);
 spike_t *spike_new(const char *set, const char *lvl,
                    size_t lane_number);
 const char *proc_disassemble(spike_processor_t *proc);
+const char *proc_disassemble_with_pc(spike_processor_t *proc, reg_t pc);
 void proc_reset(spike_processor_t *proc);
 spike_processor_t *spike_get_proc(spike_t *spike);
 spike_state_t *proc_get_state(spike_processor_t *proc);
 
 uint64_t proc_func(spike_processor_t *proc);
 uint64_t proc_get_insn(spike_processor_t *proc);
+uint64_t proc_get_insn_with_pc(spike_processor_t *proc, reg_t pc);
 uint8_t proc_get_vreg_data(spike_processor_t *proc, uint32_t vreg_idx,
                            uint32_t vreg_offset);
 uint32_t proc_get_rs1(spike_processor_t *proc);
+uint32_t proc_get_rs1_with_pc(spike_processor_t *proc, reg_t pc);
 uint32_t proc_get_rs2(spike_processor_t *proc);
+uint32_t proc_get_rs2_with_pc(spike_processor_t *proc, reg_t pc);
 uint32_t proc_get_rd(spike_processor_t *proc);
+uint32_t proc_get_rd_with_pc(spike_processor_t *proc, reg_t pc); 
 
 uint64_t proc_vu_get_vtype(spike_processor_t *proc);
 uint32_t proc_vu_get_vxrm(spike_processor_t *proc);

--- a/rocketemu/driver/src/sim.rs
+++ b/rocketemu/driver/src/sim.rs
@@ -43,7 +43,7 @@ pub struct SimulationArgs {
   pub log_level: String,
 
   /// The timeout value
-  #[arg(long, default_value_t = 1_0000)]
+  #[arg(long, default_value_t = 1_00000)]
   pub timeout: u64,
 
   #[cfg(feature = "trace")]

--- a/rocketemu/driver/src/sim.rs
+++ b/rocketemu/driver/src/sim.rs
@@ -43,7 +43,7 @@ pub struct SimulationArgs {
   pub log_level: String,
 
   /// The timeout value
-  #[arg(long, default_value_t = 1_00000)]
+  #[arg(long, default_value_t = 3_00000)]
   pub timeout: u64,
 
   #[cfg(feature = "trace")]

--- a/rocketemu/nix/verilated-csrc.nix
+++ b/rocketemu/nix/verilated-csrc.nix
@@ -43,6 +43,7 @@ stdenv.mkDerivation {
       -O1 \
       -Wno-WIDTHEXPAND \
       -Wno-LATCH \
+      -Wno-UNOPTTHREADS \
       --cc TestBench
 
     echo "[nix] building verilated C lib"

--- a/rocketemu/offline/src/difftest.rs
+++ b/rocketemu/offline/src/difftest.rs
@@ -35,7 +35,7 @@ impl Difftest {
       }
       if se.is_rd_written() && se.rd_idx != 0 {
         let event = self.dut.step()?;
-
+        
         match event {
           JsonEvents::RegWrite { addr, data, cycle } => {
             self.runner.cycle = *cycle;

--- a/rocketemu/spike_rs/src/lib.rs
+++ b/rocketemu/spike_rs/src/lib.rs
@@ -55,7 +55,7 @@ impl Spike {
 
   pub fn get_proc(&self) -> Processor {
     let processor = unsafe { spike_get_proc(self.spike) };
-    Processor { processor }
+    Processor { processor: processor, is_exception: false }
   }
 
   pub fn load_bytes_to_mem(
@@ -88,6 +88,7 @@ impl Drop for Spike {
 
 pub struct Processor {
   processor: *mut (),
+  is_exception: bool,
 }
 
 impl Processor {
@@ -179,6 +180,14 @@ impl Processor {
 
   pub fn vu_get_vstart(&self) -> u16 {
     unsafe { proc_vu_get_vstart(self.processor) }
+  }
+
+  pub fn is_exception(&self) -> bool {
+    self.is_exception
+  }
+
+  pub fn reset_exception(&mut self) {
+    self.is_exception = false
   }
 }
 

--- a/rocketemu/spike_rs/src/lib.rs
+++ b/rocketemu/spike_rs/src/lib.rs
@@ -97,6 +97,12 @@ impl Processor {
     format!("{}", c_str.to_string_lossy())
   }
 
+  pub fn disassemble_with_pc(&self, pc: u64) -> String {
+    let bytes = unsafe { proc_disassemble_with_pc(self.processor, pc) };
+    let c_str = unsafe { CStr::from_ptr(bytes as *mut c_char) };
+    format!("{}", c_str.to_string_lossy())
+  }
+
   pub fn reset(&self) {
     unsafe { proc_reset(self.processor) }
   }
@@ -114,6 +120,10 @@ impl Processor {
     unsafe { proc_get_insn(self.processor) as u32 }
   }
 
+  pub fn get_insn_with_pc(&self, pc: u64) -> u32 {
+    unsafe { proc_get_insn_with_pc(self.processor, pc) as u32 }
+  }
+
   pub fn get_vreg_data(&self, idx: u32, offset: u32) -> u8 {
     unsafe { proc_get_vreg_data(self.processor, idx, offset) }
   }
@@ -122,12 +132,24 @@ impl Processor {
     unsafe { proc_get_rs1(self.processor) }
   }
 
+  pub fn get_rs1_with_pc(&self, pc: u64) -> u32 {
+    unsafe { proc_get_rs1_with_pc(self.processor, pc) }
+  }
+
   pub fn get_rs2(&self) -> u32 {
     unsafe { proc_get_rs2(self.processor) }
   }
 
+  pub fn get_rs2_with_pc(&self, pc: u64) -> u32 {
+    unsafe { proc_get_rs2_with_pc(self.processor, pc) }
+  }
+
   pub fn get_rd(&self) -> u32 {
     unsafe { proc_get_rd(self.processor) }
+  }
+
+  pub fn get_rd_with_pc(&self, pc: u64) -> u32 {
+    unsafe { proc_get_rd_with_pc(self.processor, pc) }
   }
 
   // vu
@@ -249,14 +271,19 @@ extern "C" {
   fn spike_get_proc(spike: *mut ()) -> *mut ();
   fn spike_destruct(spike: *mut ());
   fn proc_disassemble(proc: *mut ()) -> *mut c_char;
+  fn proc_disassemble_with_pc(proc: *mut(), pc: u64) -> *mut c_char;
   fn proc_reset(proc: *mut ());
   fn proc_get_state(proc: *mut ()) -> *mut ();
   fn proc_func(proc: *mut ()) -> u64;
   fn proc_get_insn(proc: *mut ()) -> u64;
+  fn proc_get_insn_with_pc(proc: *mut(), pc: u64) -> u64; 
   fn proc_get_vreg_data(proc: *mut (), vreg_idx: u32, vreg_offset: u32) -> u8;
   fn proc_get_rs1(proc: *mut ()) -> u32;
+  fn proc_get_rs1_with_pc(proc: *mut(), pc: u64) -> u32;
   fn proc_get_rs2(proc: *mut ()) -> u32;
+  fn proc_get_rs2_with_pc(proc: *mut(), pc: u64) -> u32;
   fn proc_get_rd(proc: *mut ()) -> u32;
+  fn proc_get_rd_with_pc(proc: *mut(), pc: u64) -> u32;
 
   fn proc_vu_get_vtype(proc: *mut ()) -> u64;
   fn proc_vu_get_vxrm(proc: *mut ()) -> u32;

--- a/rocketemu/spike_rs/src/spike_event.rs
+++ b/rocketemu/spike_rs/src/spike_event.rs
@@ -5,6 +5,8 @@ use Default;
 use crate::clip;
 use crate::Spike;
 
+use tracing::debug;
+
 #[derive(Debug, Clone)]
 pub struct SingleMemWrite {
   pub val: u8,
@@ -193,6 +195,9 @@ impl SpikeEvent {
     let state = proc.get_state();
 
     let insn_bits = proc.get_insn_with_pc(pc);
+    if insn_bits == 0 {
+      return ;
+    }
     let opcode = clip(insn_bits, 0, 6);
     let width = clip(insn_bits, 12, 14);
 

--- a/rocketemu/spike_rs/src/spike_event.rs
+++ b/rocketemu/spike_rs/src/spike_event.rs
@@ -100,6 +100,44 @@ pub struct SpikeEvent {
 }
 
 impl SpikeEvent {
+  
+  pub fn new_with_pc(pc: u64, do_log_vrf: bool) -> Self {
+    SpikeEvent {
+      do_log_vrf,
+      
+      lsu_idx: LSU_IDX_DEFAULT,
+      issue_idx: ISSUE_IDX_DEFAULT,
+
+      disasm: "".to_string(),
+      pc: pc,
+      inst_bits: 0, 
+
+      rs1: 0,
+      rs2: 0,
+      rs1_bits: 0,
+      rs2_bits: 0,
+      rd_idx: 0,
+
+      vtype: 0,
+      vxrm: 0,
+      vnf: 0,
+
+      vill: false,
+      vxsat: false,
+      vl: 0,
+      vstart: 0,
+
+      rd_bits: 0,
+
+      is_rd_written: false,
+      vd_write_record: Default::default(),
+      mem_access_record: Default::default(),
+      vrf_access_record: Default::default(),
+
+      exit: false,
+    }
+  }
+
   pub fn new(spike: &Spike, do_log_vrf: bool) -> Self {
     let proc = spike.get_proc();
     let state = proc.get_state();

--- a/rocketemu/test_common/src/spike_runner.rs
+++ b/rocketemu/test_common/src/spike_runner.rs
@@ -74,24 +74,29 @@ impl SpikeRunner {
   // the spike event for difftest
   pub fn spike_step(&mut self) -> SpikeEvent {
     let spike = &self.spike;
-    let proc = self.spike.get_proc();
+    let mut proc = self.spike.get_proc();
     let state = proc.get_state();
+
+    proc.reset_exception();
 
     state.set_mcycle((self.cycle + self.spike_cycle) as usize);
     
     let mut event = SpikeEvent::new_with_pc(state.get_pc(), self.do_log_vrf);
-    //state.clear();
+    state.clear();
 
+    debug!("{:x}", state.get_pc());
     let new_pc = proc.func();
 
     // fill the SpikeEvent
-    //event.fill_event(spike);
+    if(!proc.is_exception()) {
+      event.fill_event(spike);
 
-    // inst is scalar
-    debug!("SpikeStep: spike run scalar insn ({})", event.describe_insn());
+      // inst is scalar
+      debug!("SpikeStep: spike run scalar insn ({})", event.describe_insn());
 
-    //event.log_mem_write(spike).unwrap();
-    //event.log_reg_write(spike).unwrap();
+      event.log_mem_write(spike).unwrap();
+      event.log_reg_write(spike).unwrap();
+    }
 
     state.handle_pc(new_pc).unwrap();
 

--- a/rocketemu/test_common/src/spike_runner.rs
+++ b/rocketemu/test_common/src/spike_runner.rs
@@ -79,7 +79,7 @@ impl SpikeRunner {
 
     state.set_mcycle((self.cycle + self.spike_cycle) as usize);
 
-    let mut event = SpikeEvent::new(spike, self.do_log_vrf);
+    let mut event = SpikeEvent::new_with_pc(state.get_pc(), self.do_log_vrf);
     state.clear();
 
     // inst is scalar

--- a/rocketemu/test_common/src/spike_runner.rs
+++ b/rocketemu/test_common/src/spike_runner.rs
@@ -1,5 +1,5 @@
 use std::path::Path;
-use tracing::debug;
+use tracing::{debug, info};
 
 use spike_rs::spike_event::SpikeEvent;
 use spike_rs::util::load_elf;
@@ -58,7 +58,7 @@ impl SpikeRunner {
     let state = proc.get_state();
 
     let new_pc = proc.func();
-
+    
     state.handle_pc(new_pc).unwrap();
 
     let ret = state.exit();

--- a/rocketemu/test_common/src/spike_runner.rs
+++ b/rocketemu/test_common/src/spike_runner.rs
@@ -78,15 +78,20 @@ impl SpikeRunner {
     let state = proc.get_state();
 
     state.set_mcycle((self.cycle + self.spike_cycle) as usize);
-
+    
     let mut event = SpikeEvent::new_with_pc(state.get_pc(), self.do_log_vrf);
-    state.clear();
+    //state.clear();
+
+    let new_pc = proc.func();
+
+    // fill the SpikeEvent
+    //event.fill_event(spike);
 
     // inst is scalar
     debug!("SpikeStep: spike run scalar insn ({})", event.describe_insn());
-    let new_pc = proc.func();
-    event.log_mem_write(spike).unwrap();
-    event.log_reg_write(spike).unwrap();
+
+    //event.log_mem_write(spike).unwrap();
+    //event.log_reg_write(spike).unwrap();
 
     state.handle_pc(new_pc).unwrap();
 


### PR DESCRIPTION
The `SpikeEvent` attempts to walk the page table to retrieve the instruction for difftest, but a inst page fault prevents it from completing this task. Currently, I am temporarily using a null `SpikeEvent` to avoid the page fault.
