### PR TITLE
[tests] add pytorch.matmul

### DIFF
--- a/.github/cases/blastoise/default.json
+++ b/.github/cases/blastoise/default.json
@@ -1,5 +1,7 @@
 {
   "pytorch.demo": -1,
+  "pytorch.lenet": -1,
+  "pytorch.matmul": -1,
   "mlir.rvv_vp_intrinsic_add": 436,
   "mlir.rvv_vp_intrinsic_add_scalable": 584,
   "mlir.hello": 146,

--- a/tests/pytorch/matmul/build.nix
+++ b/tests/pytorch/matmul/build.nix
@@ -1,0 +1,39 @@
+{ buildBuddyE2ETest }:
+buildBuddyE2ETest {
+  caseName = "matmul";
+
+  optPhase = ''
+    echo "Lowering forward.mlir"
+
+    python ./matmul.py \
+      | buddy-opt --pass-pipeline "builtin.module(func.func(tosa-to-linalg-named, tosa-to-arith, tosa-to-linalg, tosa-to-tensor))" \
+      | buddy-opt --convert-elementwise-to-linalg \
+        --func-bufferize-dynamic-offset \
+        --arith-bufferize \
+        --func-bufferize \
+        --tensor-bufferize \
+        --linalg-bufferize \
+        --finalizing-bufferize \
+        --batchmatmul-optimize \
+        --convert-linalg-to-affine-loops \
+        --lower-affine \
+        --lower-vector-exp \
+        --lower-rvv=rv32 \
+        --convert-vector-to-scf \
+        --convert-scf-to-cf \
+        --llvm-request-c-wrappers \
+        --convert-vector-to-llvm \
+        --convert-math-to-llvm \
+        --convert-math-to-libm \
+        --convert-arith-to-llvm \
+        --convert-func-to-llvm \
+        --expand-strided-metadata \
+        --finalize-memref-to-llvm \
+        --reconcile-unrealized-casts \
+        -o forward-lowered.mlir
+
+    optArtifacts+=(
+      "forward-lowered.mlir"
+    )
+  '';
+}

--- a/tests/pytorch/matmul/matmul.cc
+++ b/tests/pytorch/matmul/matmul.cc
@@ -1,0 +1,22 @@
+#include "memref.hpp"
+
+extern "C" void _mlir_ciface_forward(MemRef<float, 1> *output,
+                                     MemRef<float, 1> *arg1,
+                                     MemRef<float, 1> *arg2);
+
+// One-dimension, with length 512
+static const int32_t sizes[3] = {8, 8, 8};
+
+__attribute((section(".vdata"))) float input_float_1[512];
+MemRef<float, 1> input1(input_float_1, sizes);
+
+__attribute((section(".vdata"))) float input_float_2[512];
+MemRef<float, 1> input2(input_float_2, sizes);
+
+__attribute((section(".vdata"))) float output_float_1[512];
+MemRef<float, 1> output(output_float_1, sizes);
+
+extern "C" int test() {
+  _mlir_ciface_forward(&output, &input1, &input2);
+  return 0;
+}

--- a/tests/pytorch/matmul/matmul.py
+++ b/tests/pytorch/matmul/matmul.py
@@ -1,0 +1,24 @@
+import torch
+import torch._dynamo as dynamo
+from torch._inductor.decomposition import decompositions as inductor_decomp
+
+from buddy.compiler.frontend import DynamoCompiler
+from buddy.compiler.ops import tosa
+
+def main():
+    float32_in1 = torch.randn(8, 8, 8).to(torch.float32)
+    float32_in2 = torch.randn(8, 8, 8).to(torch.float32)
+
+    dynamo_compiler = DynamoCompiler(
+        primary_registry=tosa.ops_registry,
+        aot_autograd_decomposition=inductor_decomp,
+    )
+
+    graphs = dynamo_compiler.importer(torch.matmul, *(float32_in1, float32_in2))
+    graph = graphs[0]
+    graph.lower_to_top_level_ir()
+
+    print(graph._imported_module)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/0fe4d1ce-6b23-4e28-b091-8c6fa443a22a)

Seems like the batch matmul optimisation pass is now working at the latest commit of Buddy MLIR compiler.