### PR TITLE
[difftest] add "success" field in perf.json

### DIFF
--- a/.github/cases/psyduck/default.json
+++ b/.github/cases/psyduck/default.json
@@ -25,7 +25,7 @@
   "codegen.vclz_v": 6562,
   "codegen.vcompress_vm": 22201,
   "codegen.vcpop_m": 2003,
-  "codegen.vcpop_v": 100000769,
+  "codegen.vcpop_v": 6562,
   "codegen.vctz_v": 6562,
   "codegen.vdiv_vv": 34209,
   "codegen.vdiv_vx": 197052,

--- a/difftest/dpi_common/src/util.rs
+++ b/difftest/dpi_common/src/util.rs
@@ -1,6 +1,12 @@
 //! utility functions
 
 pub fn write_perf_json(cycle: u64, success: bool) {
+  // unsuccessful simulation will panic by default.
+  // However, it could be suppressed by setting env T1_SUPPRESS_PANIC_IN_FINAL=1
+  if !success && !suppress_panic_in_final() {
+    panic!("simulation ends unsuccessfully [T={cycle}]");
+  }
+
   let mut content = String::new();
   content += "{\n";
   content += &format!("    \"total_cycles\": {cycle},\n");
@@ -13,4 +19,8 @@ pub fn write_perf_json(cycle: u64, success: bool) {
       tracing::error!("failed to write 'perf.json': {e}");
     }
   }
+}
+
+fn suppress_panic_in_final() -> bool {
+  std::env::var("T1_SUPPRESS_PANIC_IN_FINAL").as_deref() == Ok("1")
 }

--- a/difftest/dpi_common/src/util.rs
+++ b/difftest/dpi_common/src/util.rs
@@ -1,9 +1,10 @@
 //! utility functions
 
-pub fn write_perf_json(cycle: u64) {
+pub fn write_perf_json(cycle: u64, success: bool) {
   let mut content = String::new();
   content += "{\n";
-  content += &format!("    \"total_cycles\": {cycle}\n");
+  content += &format!("    \"total_cycles\": {cycle},\n");
+  content += &format!("    \"success\": {success}\n");
   content += "}\n";
 
   match std::fs::write("perf.json", &content) {

--- a/difftest/dpi_t1/src/dpi.rs
+++ b/difftest/dpi_t1/src/dpi.rs
@@ -231,7 +231,9 @@ unsafe extern "C" fn t1_cosim_init() {
 
 #[no_mangle]
 unsafe extern "C" fn t1_cosim_final() {
-  dpi_common::util::write_perf_json(crate::get_t());
+  TARGET.with(|driver| {
+    dpi_common::util::write_perf_json(crate::get_t(), driver.success);
+  })
 }
 
 /// evaluate at every 1024 cycles, return reason = 0 to continue simulation,

--- a/difftest/dpi_t1/src/drive.rs
+++ b/difftest/dpi_t1/src/drive.rs
@@ -103,6 +103,7 @@ pub(crate) struct Driver {
   scope: SvScope,
 
   dump_control: DumpControl,
+  pub(crate) success: bool,
 
   pub(crate) dlen: u32,
 
@@ -132,6 +133,7 @@ impl Driver {
 
       scope,
       dump_control,
+      success: false,
 
       dlen: args.dlen,
       timeout: args.timeout,
@@ -261,6 +263,7 @@ impl Driver {
               get_t(),
               se.pc
             );
+            self.success = true;
             IssueData { meta: ISSUE_EXIT, ..Default::default() }
           } else {
             self.spike_runner.commit_queue.pop_back();

--- a/difftest/dpi_t1rocket/src/dpi.rs
+++ b/difftest/dpi_t1rocket/src/dpi.rs
@@ -284,7 +284,9 @@ unsafe extern "C" fn t1rocket_cosim_init() {
 
 #[no_mangle]
 unsafe extern "C" fn t1rocket_cosim_final() {
-  dpi_common::util::write_perf_json(crate::get_t());
+  TARGET.with(|driver| {
+    dpi_common::util::write_perf_json(crate::get_t(), driver.success);
+  });
 }
 
 /// evaluate at every 1024 cycles, return reason = 0 to continue simulation,

--- a/difftest/dpi_t1rocket/src/drive.rs
+++ b/difftest/dpi_t1rocket/src/drive.rs
@@ -121,6 +121,7 @@ pub(crate) struct Driver {
   shadow_mem: ShadowMem,
 
   pub(crate) quit: bool,
+  pub(crate) success: bool,
 }
 
 impl Driver {
@@ -142,6 +143,7 @@ impl Driver {
       shadow_mem,
 
       quit: false,
+      success: false,
     }
   }
 
@@ -305,6 +307,7 @@ impl Driver {
       let exit_data_slice = data[..4].try_into().expect("slice with incorrect length");
       if u32::from_le_bytes(exit_data_slice) == EXIT_CODE {
         info!("driver is ready to quit");
+        self.success = true;
         self.quit = true;
       }
     }

--- a/t1/src/LaneZvbb.scala
+++ b/t1/src/LaneZvbb.scala
@@ -177,6 +177,21 @@ class LaneZvbb(val parameter: LaneZvbbParam) extends VFUModule(parameter) with S
 
   val zvbbANDN = zvbbSrc & (~zvbbRs)
 
+  val zvbbPOP = {
+    val zvbbPOP8a = 0.U(4.W) ## PopCount(zvbbSrc8a).asUInt(3, 0)
+    val zvbbPOP8b = 0.U(4.W) ## PopCount(zvbbSrc8b).asUInt(3, 0)
+    val zvbbPOP8c = 0.U(4.W) ## PopCount(zvbbSrc8c).asUInt(3, 0)
+    val zvbbPOP8d = 0.U(4.W) ## PopCount(zvbbSrc8d).asUInt(3, 0)
+    Mux1H(
+      vSew,
+      Seq(
+        zvbbPOP8a ## zvbbPOP8b ## zvbbPOP8c ## zvbbPOP8d,
+        0.U(8.W) ## (zvbbPOP8a + zvbbPOP8b).asUInt(7, 0) ## 0.U(8.W) ## (zvbbPOP8c + zvbbPOP8d).asUInt(7, 0),
+        0.U(24.W) ## (zvbbPOP8a + zvbbPOP8b + zvbbPOP8c + zvbbPOP8d).asUInt(7, 0)
+      )
+    )
+  }
+
   response.data := Mux1H(
     UIntToOH(request.opcode),
     Seq(
@@ -188,7 +203,8 @@ class LaneZvbb(val parameter: LaneZvbbParam) extends VFUModule(parameter) with S
       zvbbROL,
       zvbbROR,
       zvbbSLL,
-      zvbbANDN
+      zvbbANDN,
+      zvbbPOP
     )
   )
 }

--- a/t1/src/decoder/Decoder.scala
+++ b/t1/src/decoder/Decoder.scala
@@ -343,6 +343,7 @@ object Decoder {
           case _: zvbbUop6.type => BitPat("b0110") // ror
           case _: zvbbUop7.type => BitPat("b0111") // wsll
           case _: zvbbUop8.type => BitPat("b1000") // andn
+          case _: zvbbUop9.type => BitPat("b1001") // pop
           case _ => BitPat.dontCare(4)
         }
       case _ => BitPat.dontCare(4)

--- a/t1/src/decoder/attribute/isPopcount.scala
+++ b/t1/src/decoder/attribute/isPopcount.scala
@@ -17,8 +17,7 @@ object isPopcount {
 
   def y(t1DecodePattern: T1DecodePattern): Boolean = {
     val allMatched = Seq(
-      "vcpop.m",
-      "vcpop.v"
+      "vcpop.m"
     )
     allMatched.contains(t1DecodePattern.instruction.name)
   }

--- a/t1/src/decoder/attribute/isUnsigned0.scala
+++ b/t1/src/decoder/attribute/isUnsigned0.scala
@@ -138,6 +138,7 @@ object isUnsigned0 {
       "vrev8.v",
       "vclz.v",
       "vctz.v",
+      "vcpop.v",
       "vrol.vv",
       "vrol.vx",
       "vror.vv",

--- a/t1/src/decoder/attribute/isUnsigned1.scala
+++ b/t1/src/decoder/attribute/isUnsigned1.scala
@@ -110,6 +110,7 @@ object isUnsigned1 {
       "vrev8.v",
       "vclz.v",
       "vctz.v",
+      "vcpop.v",
       "vrol.vv",
       "vrol.vx",
       "vror.vv",

--- a/t1/src/decoder/attribute/isZvbb.scala
+++ b/t1/src/decoder/attribute/isZvbb.scala
@@ -26,6 +26,7 @@ object isZvbb {
           "vrev8.v",
           "vclz.v",
           "vctz.v",
+          "vcpop.v",
           "vrol.vv",
           "vrol.vx",
           "vror.vv",

--- a/t1/src/decoder/attribute/zvbbUop.scala
+++ b/t1/src/decoder/attribute/zvbbUop.scala
@@ -15,6 +15,7 @@ object zvbbUop5   extends ZvbbUOPType // rol
 object zvbbUop6   extends ZvbbUOPType // ror
 object zvbbUop7   extends ZvbbUOPType // wsll
 object zvbbUop8   extends ZvbbUOPType // andn
+object zvbbUop9   extends ZvbbUOPType // pop
 
 object ZvbbUOP {
   def apply(t1DecodePattern: T1DecodePattern): Uop     = {
@@ -27,7 +28,8 @@ object ZvbbUOP {
       t5 _ -> zvbbUop5,
       t6 _ -> zvbbUop6,
       t7 _ -> zvbbUop7,
-      t8 _ -> zvbbUop8
+      t8 _ -> zvbbUop8,
+      t9 _ -> zvbbUop9
     ).collectFirst {
       case (fn, tpe) if fn(t1DecodePattern) => tpe
     }.getOrElse(UopDC)
@@ -89,6 +91,12 @@ object ZvbbUOP {
     val allMatched: Seq[String] = Seq(
       "vandn.vv",
       "vandn.vx"
+    )
+    allMatched.contains(t1DecodePattern.instruction.name)
+  }
+  def t9(t1DecodePattern: T1DecodePattern):    Boolean = {
+    val allMatched: Seq[String] = Seq(
+      "vcpop.v"
     )
     allMatched.contains(t1DecodePattern.instruction.name)
   }


### PR DESCRIPTION
It indicates "online dpi" finishes normally , rather than terminated due to timeout.

Now a simulation finishing normally will generate perf.json as follows:
```json
{
    "total_cycles": 32444,
    "success": true
}
```

Updata:

Unsuccessful simulation will now panic in final block. However, it could be suppressed by setting environment variable "T1_SUPPRESS_PANIC_IN_FINAL=1".