### PR TITLE
[RFC] emulation devices for t1rocket

### DIFF
--- a/.github/designs/blastoise/t1rocketemu.json
+++ b/.github/designs/blastoise/t1rocketemu.json
@@ -513,7 +513,6 @@
   "mlir.stripmining": 10240,
   "mlir.vectoradd": 17183,
   "pytorch.demo": 31505,
-  "pytorch.lenet": 39103483,
   "pytorch.matmul": 69715,
   "rvv_bench.ascii_to_utf16": 702646,
   "rvv_bench.ascii_to_utf32": 233241,

--- a/difftest/dpi_t1rocketemu/src/bus.rs
+++ b/difftest/dpi_t1rocketemu/src/bus.rs
@@ -91,7 +91,7 @@ impl ShadowBus {
         }
       }
       None => {
-        error!("read addr={addr:#x} size={size}B dlen={bus_size}B leads to nowhere!");
+        panic!("read addr={addr:#x} size={size}B dlen={bus_size}B leads to nowhere!");
         vec![0; bus_size as usize]
       }
     }
@@ -132,7 +132,7 @@ impl ShadowBus {
         device.write_mem_chunk(offset, bus_size as usize, Option::from(masks), data);
       }
       None => {
-        error!("write addr={addr:#x} size={size}B dlen={bus_size}B leads to nowhere!");
+        panic!("write addr={addr:#x} size={size}B dlen={bus_size}B leads to nowhere!");
       }
     }
   }

--- a/difftest/dpi_t1rocketemu/src/bus.rs
+++ b/difftest/dpi_t1rocketemu/src/bus.rs
@@ -1,0 +1,160 @@
+mod mem;
+
+use mem::*;
+use tracing::{debug, error, trace};
+
+trait ShadowDevice: Send + Sync {
+  fn new() -> Box<dyn ShadowDevice>
+  where
+    Self: Sized;
+  /// addr: offset respect to the base of this device
+  fn read_mem(&self, addr: usize, size: usize) -> &[u8];
+  /// addr: offset respect to the base of this device
+  fn write_mem(&mut self, addr: usize, data: u8);
+  /// addr: offset respect to the base of this device
+  /// strobe: signals which element in data is valid, None = all valid
+  fn write_mem_chunk(&mut self, addr: usize, size: usize, strobe: Option<&[bool]>, data: &[u8]);
+}
+
+struct ShadowBusDevice {
+  base: usize,
+  size: usize,
+  device: Box<dyn ShadowDevice>,
+}
+
+const MAX_DEVICES: usize = 3;
+
+pub(crate) struct ShadowBus {
+  devices: [ShadowBusDevice; MAX_DEVICES],
+}
+
+impl ShadowBus {
+  /// Initiate the devices on the bus as specified in `tests/t1.ld`
+  /// NOTE: For some reason DDR is not aligned in the address space
+  pub fn new() -> Self {
+    const DDR_SIZE: usize = 0x80000000;
+    const SCALAR_SIZE: usize = 0x20000000;
+    const SRAM_SIZE: usize = 0x00400000;
+
+    Self {
+      devices: [
+        ShadowBusDevice {
+          base: 0x20000000,
+          size: SCALAR_SIZE,
+          device: MemDevice::<SCALAR_SIZE>::new(),
+        },
+        ShadowBusDevice {
+          base: 0x40000000,
+          size: DDR_SIZE,
+          device: MemDevice::<DDR_SIZE>::new(),
+        },
+        ShadowBusDevice {
+          base: 0xc0000000,
+          size: SRAM_SIZE,
+          device: MemDevice::<SRAM_SIZE>::new(),
+        },
+      ],
+    }
+  }
+
+  // size: 1 << arsize
+  // bus_size: AXI bus width in bytes
+  // return: Vec<u8> with len=bus_size
+  // if size < bus_size, the result is padded due to AXI narrow transfer rules
+  pub fn read_mem_axi(&self, addr: u32, size: u32, bus_size: u32) -> Vec<u8> {
+    assert!(
+      addr % size == 0 && bus_size % size == 0,
+      "unaligned access addr={addr:#x} size={size}B dlen={bus_size}B"
+    );
+
+    let start = addr as usize;
+    let end = (addr + size) as usize;
+
+    let handler = self.devices.iter().find(|d| match d {
+      ShadowBusDevice { base, size, device: _ } => *base <= start && end <= (*base + *size),
+    });
+
+    match handler {
+      Some(ShadowBusDevice { base, size: _, device }) => {
+        let offset = start - *base;
+        let data = device.read_mem(offset, size as usize);
+
+        if size < bus_size {
+          let mut data_padded = vec![0; bus_size as usize];
+          let start = (addr % bus_size) as usize;
+          let end = start + data.len();
+          data_padded[start..end].copy_from_slice(data);
+
+          data_padded
+        } else {
+          data.to_vec()
+        }
+      }
+      None => {
+        error!("read addr={addr:#x} size={size}B dlen={bus_size}B leads to nowhere!");
+        vec![0; bus_size as usize]
+      }
+    }
+  }
+
+  // size: 1 << awsize
+  // bus_size: AXI bus width in bytes
+  // masks: write strobes, len=bus_size
+  // data: write data, len=bus_size
+  pub fn write_mem_axi(
+    &mut self,
+    addr: u32,
+    size: u32,
+    bus_size: u32,
+    masks: &[bool],
+    data: &[u8],
+  ) {
+    assert!(
+      addr % size == 0 && bus_size % size == 0,
+      "unaligned write access addr={addr:#x} size={size}B dlen={bus_size}B"
+    );
+
+    if !masks.iter().any(|x| *x) {
+      trace!("Mask 0 write detected");
+      return;
+    }
+
+    let start = (addr & ((!bus_size) + 1)) as usize;
+    let end = start + bus_size as usize;
+
+    let handler = self.devices.iter_mut().find(|d| match d {
+      ShadowBusDevice { base, size, device: _ } => *base <= start && end <= (*base + *size),
+    });
+
+    match handler {
+      Some(ShadowBusDevice { base, size: _, device }) => {
+        let offset = start - *base;
+        device.write_mem_chunk(offset, bus_size as usize, Option::from(masks), data);
+      }
+      None => {
+        error!("write addr={addr:#x} size={size}B dlen={bus_size}B leads to nowhere!");
+      }
+    }
+  }
+
+  pub fn load_mem_seg(&mut self, vaddr: usize, data: &[u8]) {
+    let handler = self
+      .devices
+      .iter_mut()
+      .find(|d| match d {
+        ShadowBusDevice { base, size, device: _ } => {
+          *base <= vaddr as usize && (vaddr as usize + data.len()) <= (*base + *size)
+        }
+      })
+      .unwrap_or_else(|| {
+        panic!(
+          "fail reading ELF into mem with vaddr={:#x}, len={}B: load memory to nowhere",
+          vaddr,
+          data.len()
+        )
+      });
+
+    let offset = vaddr - handler.base;
+    handler.device.write_mem_chunk(offset, data.len(), None, data)
+  }
+}

--- a/difftest/dpi_t1rocketemu/src/bus/mem.rs
+++ b/difftest/dpi_t1rocketemu/src/bus/mem.rs
@@ -1,0 +1,40 @@
+use super::ShadowDevice;
+
+pub(super) struct MemDevice<const SIZE: usize> {
+  mem: Box<[u8; SIZE]>,
+}
+
+impl<const SIZE: usize> ShadowDevice for MemDevice<SIZE> {
+  fn new() -> Box<dyn ShadowDevice>
+  where
+    Self: Sized,
+  {
+    Box::new(Self { mem: vec![0u8; SIZE].try_into().unwrap() })
+  }
+
+  fn read_mem(&self, addr: usize, size: usize) -> &[u8] {
+    let start = addr;
+    let end = addr + size;
+    &self.mem[start..end]
+  }
+
+  fn write_mem(&mut self, addr: usize, data: u8) {
+    self.mem[addr] = data;
+  }
+
+  fn write_mem_chunk(&mut self, addr: usize, size: usize, strobe: Option<&[bool]>, data: &[u8]) {
+    // NOTE: addr & size alignment check already done in ShadowBus, and ELF load can be unaligned anyway.
+
+    if let Some(masks) = strobe {
+      masks.iter().enumerate().for_each(|(i, mask)| {
+        if *mask {
+          self.mem[addr + i] = data[i];
+        }
+      })
+    } else {
+      let start = addr;
+      let end = addr + size;
+      self.mem[start..end].copy_from_slice(data);
+    }
+  }
+}

--- a/difftest/dpi_t1rocketemu/src/lib.rs
+++ b/difftest/dpi_t1rocketemu/src/lib.rs
@@ -2,6 +2,7 @@ use std::path::PathBuf;
 
 use dpi_common::plusarg::PlusArgMatcher;
 
+mod bus;
 pub mod dpi;
 pub mod drive;
 

--- a/tests/asm/memcpy/memcpy.S
+++ b/tests/asm/memcpy/memcpy.S
@@ -45,14 +45,14 @@ test:
 
     # fill 0x1001000 with 0x55 x 4096 bytes
     # a0: void* dest, a1: int n, a2: size_t len
-    lw a0, test_src_start
+    la a0, test_src_start
     li a1, 0x55
     li a2, 0x1000
     call memset
     # copy 0x1001000 to 0x1000000 with 4096 bytes
     # a0: void* dest, a1: void* src, a2: size_t n
-    lw a0, test_src_start
-    lw a1, test_dst_start
+    la a0, test_src_start
+    la a1, test_dst_start
     li a2, 0x1000
     call memcpy
 

--- a/tests/asm/mmm/mmm.S
+++ b/tests/asm/mmm/mmm.S
@@ -14,10 +14,10 @@
 test:
 
 # a0: uint32_t result, a1: uint32_t *a, a2: uint32_t *b, a3: uint32_t *p
-    lw a0, mmm_result
-    lw a1, mmm_a
-    lw a2, mmm_b
-    lw a3, mmm_p
+    la a0, mmm_result
+    la a1, mmm_a
+    la a2, mmm_b
+    la a3, mmm_p
 
 # for (int i = 0; i < 16; i++) a[i] = b[i] = p[i] = i;
     li      a4, 0
@@ -32,10 +32,10 @@ test:
     addi    a3, a3, 4
     bne     a4, a5, .LBB0_1
 
-    lw a0, mmm_result
-    lw a1, mmm_a
-    lw a2, mmm_b
-    lw a3, mmm_p
+    la a0, mmm_result
+    la a1, mmm_a
+    la a2, mmm_b
+    la a3, mmm_p
 
 # begin mmm main program
 

--- a/tests/asm/smoke/smoke.S
+++ b/tests/asm/smoke/smoke.S
@@ -5,7 +5,7 @@ test:
     li a1, 0xc3
     li a2, 0x10
     vsetvl x0, a0, a1
-    lui x30, 1
+    la x30, test_src_start
     auipc x31, 0
 
 add_test:
@@ -31,3 +31,8 @@ loop:
 
 will_not_be_executed:
     vadd.vv v2, v1, v1
+
+.section .vbss, "aw", @nobits
+.balign 64
+test_src_start:
+    .zero 8

--- a/tests/asm/strlen/strlen.S
+++ b/tests/asm/strlen/strlen.S
@@ -47,13 +47,13 @@ test:
 
     # fill 0x1000000 with 0x55 x 4096 bytes
     # a0: void* dest, a1: int n, a2: size_t len
-    lw a0, test_str_start
+    la a0, test_str_start
     li a1, 0x55
     li a2, 0x1000
     call memset
     # Call strlen to calculate the length of the string starting at memory address 0x1000000
     # a0: const char *str
-    lw a0, test_str_start
+    la a0, test_str_start
     call strlen
 
     lw ra, 0(sp)

--- a/tests/codegen/include/riscv_test.h
+++ b/tests/codegen/include/riscv_test.h
@@ -118,7 +118,7 @@
 #define RVTEST_FP_VECTOR_ENABLE                                                \
   li a0, (MSTATUS_VS & (MSTATUS_VS >> 1)) | (MSTATUS_FS & (MSTATUS_FS >> 1));  \
   csrs mstatus, a0;                                                            \
-  csrwi fcsr, 0;
+  csrwi fcsr, 0;                                                               \
   csrwi vcsr, 0;
 
 #define RVTEST_VECTOR_ENABLE                                                   \
@@ -159,7 +159,8 @@
 #define RVTEST_CODE_END                                                        \
   li x1, 0x40000000;                                                           \
   li x2, 0xdeadbeef;                                                           \
-  sw x2, 0(x1);
+  sw x2, 0(x1);                                                                \
+  j .;
 
 //-----------------------------------------------------------------------
 // Pass/Fail Macro

--- a/tests/emurt/emurt.c
+++ b/tests/emurt/emurt.c
@@ -57,6 +57,7 @@ void _exit(int code) {
   __asm__("li x1, 0x40000000");
   __asm__("li x2, 0xdeadbeef");
   __asm__("sw x2, 0(x1)");
+  __asm__("j .");
   __builtin_unreachable();
 }
 

--- a/tests/riscv-test-env/p/riscv_test.h
+++ b/tests/riscv-test-env/p/riscv_test.h
@@ -242,7 +242,8 @@ reset_vector:                                                           \
 #define RVTEST_CODE_END                                                 \
         li x1, EXIT_POS;                                                \
         li x2, EXIT_CODE;                                               \
-        sw x2, 0(x1);
+        sw x2, 0(x1);                                                   \
+        j .;
 
 //-----------------------------------------------------------------------
 // Pass/Fail Macro

--- a/tests/t1_main.S
+++ b/tests/t1_main.S
@@ -13,5 +13,6 @@ _start:
     li x1, 0x40000000
     li x2, 0xdeadbeef
     sw x2, 0(x1)
+    j .
 
     .p2align 2


### PR DESCRIPTION
Add extensible devices emulation for t1rocket simulation dpi backend. Currently only simple Memory device is implemented, and more devices with more functionality are expected to come.