### PR TITLE
[RFC] DisplayDevice for t1rocket emulation

### DIFF
--- a/difftest/Cargo.lock
+++ b/difftest/Cargo.lock
@@ -3,6 +3,12 @@
 version = 3
 
 [[package]]
+name = "adler2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -73,6 +79,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -125,6 +137,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
 
 [[package]]
+name = "crc32fast"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "dpi_common"
 version = "0.1.0"
 dependencies = [
@@ -152,6 +173,7 @@ dependencies = [
  "dpi_common",
  "elf",
  "hex",
+ "png",
  "spike_rs",
  "svdpi",
  "tracing",
@@ -162,6 +184,25 @@ name = "elf"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4445909572dbd556c457c849c4ca58623d84b27c8fff1e74b0b4227d8b90d17b"
+
+[[package]]
+name = "fdeflate"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8090f921a24b04994d9929e204f50b498a33ea6ba559ffaa05e04f7ee7fb5ab"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
+name = "flate2"
+version = "1.0.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1b589b4dc103969ad3cf85c950899926ec64300a1a46d76c03a6072957036f0"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "heck"
@@ -229,6 +270,16 @@ name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
 
 [[package]]
 name = "nu-ansi-term"
@@ -317,6 +368,19 @@ name = "pin-project-lite"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
+
+[[package]]
+name = "png"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f9d46a34a05a6a57566bc2bfae066ef07585a6e3fa30fbbdff5936380623f0"
+dependencies = [
+ "bitflags",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -425,6 +489,12 @@ checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 
 [[package]]
 name = "smallvec"

--- a/difftest/dpi_t1rocketemu/Cargo.toml
+++ b/difftest/dpi_t1rocketemu/Cargo.toml
@@ -16,5 +16,6 @@ svdpi = { workspace = true }
 anyhow = { workspace = true }
 hex = "0.4.3"
 elf = "0.7.4"
+png = "0.17.14"
 
 [features]

--- a/difftest/dpi_t1rocketemu/src/bus.rs
+++ b/difftest/dpi_t1rocketemu/src/bus.rs
@@ -1,3 +1,4 @@
+mod disp;
 mod mem;
 
 use mem::*;

--- a/difftest/dpi_t1rocketemu/src/bus.rs
+++ b/difftest/dpi_t1rocketemu/src/bus.rs
@@ -8,7 +8,7 @@ trait ShadowDevice: Send + Sync {
   where
     Self: Sized;
   /// addr: offset respect to the base of this device
-  fn read_mem(&self, addr: usize, size: usize) -> &[u8];
+  fn read_mem(&self, addr: usize, size: usize) -> Vec<u8>;
   /// addr: offset respect to the base of this device
   fn write_mem(&mut self, addr: usize, data: u8);
   /// addr: offset respect to the base of this device

--- a/difftest/dpi_t1rocketemu/src/bus.rs
+++ b/difftest/dpi_t1rocketemu/src/bus.rs
@@ -1,6 +1,7 @@
 mod disp;
 mod mem;
 
+use disp::*;
 use mem::*;
 use tracing::{debug, error, trace};
 
@@ -23,7 +24,7 @@ struct ShadowBusDevice {
   device: Box<dyn ShadowDevice>,
 }
 
-const MAX_DEVICES: usize = 3;
+const MAX_DEVICES: usize = 4;
 
 pub(crate) struct ShadowBus {
   devices: [ShadowBusDevice; MAX_DEVICES],
@@ -39,6 +40,11 @@ impl ShadowBus {
 
     Self {
       devices: [
+        ShadowBusDevice {
+          base: 0x04000000,
+          size: 0x02000000,
+          device: DisplayDevice::new(),
+        },
         ShadowBusDevice {
           base: 0x20000000,
           size: SCALAR_SIZE,
@@ -84,11 +90,11 @@ impl ShadowBus {
           let mut data_padded = vec![0; bus_size as usize];
           let start = (addr % bus_size) as usize;
           let end = start + data.len();
-          data_padded[start..end].copy_from_slice(data);
+          data_padded[start..end].copy_from_slice(&data);
 
           data_padded
         } else {
-          data.to_vec()
+          data
         }
       }
       None => {

--- a/difftest/dpi_t1rocketemu/src/bus/disp.rs
+++ b/difftest/dpi_t1rocketemu/src/bus/disp.rs
@@ -1,0 +1,138 @@
+use super::ShadowDevice;
+use std::fs::File;
+use std::io::BufWriter;
+use std::path::PathBuf;
+
+/// Device memory layout:
+/// `0x000_0000 - 0x1FF_0000` addressable frame buffer memory
+///   Picture is in packed RGB24 layout, row-major. See tests/disp/simple for example.
+///   OUTPUT_WIDTH * OUTPUT_HEIGHT writable, out-of-range writes will be ignored
+/// `0x1FF_0000 - 0x200_0000` control registers
+/// `0x1FF_0000`: read as frame counter, write to flush frame buffer as png
+/// `0x1FF_0004`: output dimensions
+///     0x04-06 16bits: OUTPUT_WIDTH (currently fixed at 960)
+///     0x06-08 16bits: OUTPUT_HEIGHT (currently fixed at 720)
+/// TODO: configurable dimension and color depth support?
+/// TODO: behavior emulation closer to actual LCD display?
+pub(super) struct DisplayDevice {
+  vram: Vec<u8>,
+  frame_counter: i32,
+}
+
+const DISPLAY_WIDTH: u32 = 960;
+const DISPLAY_HEIGHT: u32 = 720;
+
+const REG_START: usize = 0x1FF0000;
+const REG_FLUSH: usize = 0x1FF0000;
+const REG_DIM: usize = 0x1FF0020;
+
+impl ShadowDevice for DisplayDevice {
+  fn new() -> Box<dyn ShadowDevice>
+  where
+    Self: Sized,
+  {
+    Box::new(Self {
+      vram: vec![0u8; (DISPLAY_WIDTH * DISPLAY_HEIGHT * 3) as usize],
+      frame_counter: 0,
+    })
+  }
+
+  fn read_mem(&self, addr: usize, size: usize) -> Vec<u8> {
+    let start = addr;
+    let end = addr + size;
+
+    assert!(
+      !(start < REG_START && end > REG_START),
+      "Read burst should not cross register boundary"
+    );
+
+    if start < REG_START {
+      self.vram_read(addr, size)
+    } else {
+      self.reg_read(addr - REG_START, size)
+    }
+  }
+
+  fn write_mem(&mut self, addr: usize, data: u8) {
+    if addr < self.vram.len() {
+      self.vram[addr] = data;
+    } else if addr == REG_FLUSH {
+      self.encode_png().unwrap();
+      self.frame_counter += 1;
+    }
+  }
+
+  fn write_mem_chunk(&mut self, addr: usize, size: usize, strobe: Option<&[bool]>, data: &[u8]) {
+    let start = addr;
+    let end = addr + size;
+
+    if end <= self.vram.len() {
+      if let Some(masks) = strobe {
+        masks.iter().enumerate().for_each(|(i, mask)| {
+          if *mask {
+            self.vram[addr + i] = data[i];
+          }
+        })
+      } else {
+        let start = addr;
+        let end = addr + size;
+        self.vram[start..end].copy_from_slice(data);
+      }
+    } else {
+      if let Some(masks) = strobe {
+        masks.iter().enumerate().for_each(|(i, mask)| {
+          if *mask {
+            self.write_mem(addr + i, data[i]);
+          }
+        })
+      } else {
+        for i in start..end {
+          self.write_mem(addr + i, data[i]);
+        }
+      }
+    }
+  }
+}
+
+impl DisplayDevice {
+  fn vram_read(&self, offset: usize, size: usize) -> Vec<u8> {
+    let mut buffer = vec![0u8; size];
+    let start = std::cmp::min(self.vram.len(), offset);
+    let end = std::cmp::min(self.vram.len(), offset + size);
+    (&mut buffer[0..(start - end)]).copy_from_slice(&self.vram[start..end]);
+    buffer
+  }
+
+  fn reg_read(&self, offset: usize, size: usize) -> Vec<u8> {
+    let mut buffer = vec![0u8; size];
+    let counter = self.frame_counter.to_le_bytes().into_iter();
+    let width = (DISPLAY_WIDTH as u16).to_le_bytes().into_iter();
+    let height = (DISPLAY_HEIGHT as u16).to_le_bytes().into_iter();
+    let reg_space: Vec<u8> = counter.chain(width).chain(height).collect();
+
+    let start = std::cmp::min(reg_space.len(), offset);
+    let end = std::cmp::min(reg_space.len(), offset + size);
+    (&mut buffer[0..(end - start)]).copy_from_slice(&reg_space[start..end]);
+    buffer
+  }
+
+  fn encode_png(&self) -> anyhow::Result<()> {
+    let out_dir = PathBuf::from(
+      std::env::var("DISP_OUT_DIR").unwrap_or("./t1-sim-result/result/pngs".to_string()),
+    );
+    std::fs::create_dir_all(&out_dir)?;
+
+    let path = out_dir.join(format!("frame_{}.png", self.frame_counter));
+    let file = File::create(path)?;
+    let ref mut w = BufWriter::new(file);
+
+    let mut encoder = png::Encoder::new(w, DISPLAY_WIDTH, DISPLAY_HEIGHT);
+    encoder.set_color(png::ColorType::Rgb);
+    encoder.set_depth(png::BitDepth::Eight);
+    encoder.set_srgb(png::SrgbRenderingIntent::Perceptual);
+
+    let mut writer = encoder.write_header()?;
+    writer.write_image_data(&self.vram)?;
+    Ok(())
+  }
+}

--- a/difftest/dpi_t1rocketemu/src/bus/mem.rs
+++ b/difftest/dpi_t1rocketemu/src/bus/mem.rs
@@ -12,10 +12,10 @@ impl<const SIZE: usize> ShadowDevice for MemDevice<SIZE> {
     Box::new(Self { mem: vec![0u8; SIZE].try_into().unwrap() })
   }
 
-  fn read_mem(&self, addr: usize, size: usize) -> &[u8] {
+  fn read_mem(&self, addr: usize, size: usize) -> Vec<u8> {
     let start = addr;
     let end = addr + size;
-    &self.mem[start..end]
+    self.mem[start..end].to_vec()
   }
 
   fn write_mem(&mut self, addr: usize, data: u8) {

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -89,11 +89,12 @@ let
     codegen = casesSelf.callPackage ./codegen { };
     rvv_bench = casesSelf.callPackage ./rvv_bench { };
     pytorch = casesSelf.callPackage ./pytorch { };
+    disp = casesSelf.callPackage ./disp { };
   }));
 
   # remove non-case attributes in scope
   scopeStripped = {
-    inherit (scope) mlir intrinsic asm perf codegen rvv_bench pytorch;
+    inherit (scope) mlir intrinsic asm perf codegen rvv_bench pytorch disp;
   };
 
   # This derivation is for internal CI use only.

--- a/tests/disp/default.nix
+++ b/tests/disp/default.nix
@@ -1,0 +1,34 @@
+{ lib
+, linkerScript
+, makeBuilder
+, findAndBuild
+, t1main
+, getTestRequiredFeatures
+}:
+
+let
+  builder = makeBuilder { casePrefix = "disp"; };
+  build = { caseName, sourcePath }:
+    builder {
+      inherit caseName;
+
+      src = sourcePath;
+
+      passthru.featuresRequired = getTestRequiredFeatures sourcePath;
+
+      buildPhase = ''
+        runHook preBuild
+
+        $CC -T${linkerScript} \
+          ${caseName}.c \
+          ${t1main} \
+          -o $pname.elf
+
+        runHook postBuild
+      '';
+
+      meta.description = "test case '${caseName}' for display devices, written in C";
+    };
+in
+findAndBuild ./. build
+

--- a/tests/disp/simple/simple.c
+++ b/tests/disp/simple/simple.c
@@ -1,0 +1,37 @@
+#include <stdint.h>
+
+typedef struct __attribute__((packed)) pixel {
+    uint8_t r;
+    uint8_t g;
+    uint8_t b;
+} pixel_t;
+
+volatile int32_t *counter = (int32_t*) 0x05ff0000;
+pixel_t *buffer = (pixel_t *) 0x04000000;
+
+void test() {
+    for (int i = 0; i < 720; i++) {
+        for (int j = 0; j < 320; j++) {
+            buffer[i * 960 + j].r = 0xf0;
+            buffer[i * 960 + j].g = 0x00;
+            buffer[i * 960 + j].b = 0x00;
+        }
+        for (int j = 320; j < 640; j++) {
+            buffer[i * 960 + j].r = 0x00;
+            buffer[i * 960 + j].g = 0xf0;
+            buffer[i * 960 + j].b = 0x00;
+        }
+        for (int j = 640; j < 960; j++) {
+            buffer[i * 960 + j].r = 0x00;
+            buffer[i * 960 + j].g = 0x00;
+            buffer[i * 960 + j].b = 0xf0;
+        }
+    }
+    *counter = 0;
+    for (int i = 0; i < 720; i++) {
+        for (int j = 0; j < 320; j ++) {
+            buffer[i * 960 + j].b = 0xf0;
+        }
+    }
+    *counter = 0;
+}


### PR DESCRIPTION
Depends on #800 , this PR contains followup DisplayDevice implementation.

Currently it simply dumps a fixed-size RGB buffer to disk as png upon writing to a control register. The specific interfaces are open to futher discussion.