### PR TITLE
Remove embedded ClockGen in TestBench

### DIFF
--- a/nix/t1/default.nix
+++ b/nix/t1/default.nix
@@ -97,13 +97,13 @@ lib.makeScope newScope
     # * verilatorTop: Top module of the system verilog, default using "TestBench"
     # * verilatorThreads: Threads for final verilating, default using 8
     # * verilatorArgs: Final arguments that pass to the verilator.
-    sv-to-verilator-emulator = t1Scope.callPackage ./conversion/sv-to-verilator-emulator.nix { stdenv = moldStdenv; };
+    sv-to-verilator-emulator = lib.makeOverridable (t1Scope.callPackage ./conversion/sv-to-verilator-emulator.nix { stdenv = moldStdenv; });
 
     # sv-to-vcs-simulator :: { mainProgram :: String, rtl :: Derivation, enableTrace :: Bool, vcsLinkLibs :: List<String> } -> Derivation
     #
     # sv-to-vcs-simulator will compile the given rtl, link with path specified in vcsLinksLibs to produce a VCS emulator.
     # enableTrace is false by default;
-    sv-to-vcs-simulator = t1Scope.callPackage ./conversion/sv-to-vcs-simulator.nix { };
+    sv-to-vcs-simulator = lib.makeOverridable (t1Scope.callPackage ./conversion/sv-to-vcs-simulator.nix { });
   }
     # Nix specification for t1 (with spike only) emulator
     # We don't expect extra scope for t1 stuff, so here we merge the t1 at t1Scope level.

--- a/nix/t1/run/run-vcs-emu.nix
+++ b/nix/t1/run/run-vcs-emu.nix
@@ -16,6 +16,7 @@ stdenvNoCC.mkDerivation (finalAttr: {
       "+t1_elf_file=${testCase}/bin/${testCase.pname}.elf"
       ${lib.optionalString emulator.enableTrace "+t1_wave_path=${testCase.pname}.fsdb"}
       "-cm assert"
+      "-assert global_finish_maxfail=10000"
     )
     emuDriverArgs="''${emuDriverArgsArray[@]}"
     emuDriver="${emulator}/bin/${emulator.mainProgram}"

--- a/t1emu/src/TestBench.scala
+++ b/t1emu/src/TestBench.scala
@@ -39,42 +39,9 @@ class TestBench(val parameter: T1Parameter)
   val om:         Property[ClassType]   = IO(Output(Property[omType.Type]()))
   om := omInstance.getPropertyReference
 
-  val clockGen = Module(new ExtModule with HasExtModuleInline {
+  val clockGen = Module(new ExtModule {
 
     override def desiredName = "ClockGen"
-    setInline(
-      s"$desiredName.sv",
-      s"""module $desiredName(output reg clock, output reg reset);
-         |`ifdef T1_ENABLE_TRACE
-         |  export "DPI-C" function dump_wave;
-         |  function dump_wave(input string file);
-         |`ifdef VCS
-         |    $$fsdbDumpfile(file);
-         |    $$fsdbDumpvars("+all");
-         |    $$fsdbDumpon;
-         |`endif
-         |`ifdef VERILATOR
-         |    $$dumpfile(file);
-         |    $$dumpvars(0);
-         |`endif
-         |  endfunction;
-         |`endif
-         |
-         |  import "DPI-C" context function void t1_cosim_init();
-         |  import "DPI-C" context function void t1_cosim_final();
-         |  initial begin
-         |    t1_cosim_init();
-         |    clock = 1'b0;
-         |    reset = 1'b1;
-         |  end
-         |  final begin
-         |    t1_cosim_final();
-         |  end
-         |  initial #(11) reset = 1'b0;
-         |  always #10 clock = ~clock;
-         |endmodule
-         |""".stripMargin
-    )
     val clock                = IO(Output(Bool()))
     val reset                = IO(Output(Bool()))
   })

--- a/t1emu/vsrc/ClockGen.sv
+++ b/t1emu/vsrc/ClockGen.sv
@@ -1,0 +1,29 @@
+module ClockGen(output reg clock, output reg reset);
+`ifdef T1_ENABLE_TRACE
+  export "DPI-C" function dump_wave;
+  function dump_wave(input string file);
+`ifdef VCS
+    $fsdbDumpfile(file);
+    $fsdbDumpvars("+all");
+    $fsdbDumpon;
+`endif
+`ifdef VERILATOR
+    $dumpfile(file);
+    $dumpvars(0);
+`endif
+  endfunction;
+`endif
+
+  import "DPI-C" context function void t1_cosim_init();
+  import "DPI-C" context function void t1_cosim_final();
+  initial begin
+    t1_cosim_init();
+    clock = 1'b0;
+    reset = 1'b1;
+  end
+  final begin
+    t1_cosim_final();
+  end
+  initial #(11) reset = 1'b0;
+  always #10 clock = ~clock;
+endmodule

--- a/t1rocketemu/src/TestBench.scala
+++ b/t1rocketemu/src/TestBench.scala
@@ -39,47 +39,8 @@ class TestBench(val parameter: T1RocketTileParameter)
   val om:         Property[ClassType]   = IO(Output(Property[omType.Type]()))
   om := omInstance.getPropertyReference
 
-  val clockGen               = Module(new ExtModule with HasExtModuleInline {
+  val clockGen               = Module(new ExtModule {
     override def desiredName = "ClockGen"
-    setInline(
-      s"$desiredName.sv",
-      s"""module $desiredName(output reg clock, output reg reset);
-         |`ifdef T1_ENABLE_TRACE
-         |  export "DPI-C" function dump_wave;
-         |  function dump_wave(input string file);
-         |`ifdef VCS
-         |    $$fsdbDumpfile(file);
-         |    $$fsdbDumpvars("+all");
-         |    $$fsdbDumpon;
-         |`endif
-         |`ifdef VERILATOR
-         |    $$dumpfile(file);
-         |    $$dumpvars(0);
-         |`endif
-         |  endfunction;
-         |`endif
-         |
-         |  export "DPI-C" function quit;
-         |  function quit();
-         |    $$finish;
-         |  endfunction;
-         |
-         |  import "DPI-C" context function void t1rocket_cosim_init();
-         |  import "DPI-C" context function void t1rocket_cosim_final();
-         |  initial begin
-         |    t1rocket_cosim_init();
-         |    clock = 1'b0;
-         |    reset = 1'b1;
-         |  end
-         |  final begin
-         |    t1rocket_cosim_final();
-         |  end
-         |
-         |  initial #(100) reset = 1'b0;
-         |  always #10 clock = ~clock;
-         |endmodule
-         |""".stripMargin
-    )
     val clock                = IO(Output(Bool()))
     val reset                = IO(Output(Bool()))
   })

--- a/t1rocketemu/vsrc/ClockGen.sv
+++ b/t1rocketemu/vsrc/ClockGen.sv
@@ -1,0 +1,35 @@
+module ClockGen(output reg clock, output reg reset);
+`ifdef T1_ENABLE_TRACE
+  export "DPI-C" function dump_wave;
+  function dump_wave(input string file);
+`ifdef VCS
+    $fsdbDumpfile(file);
+    $fsdbDumpvars("+all");
+    $fsdbDumpon;
+`endif
+`ifdef VERILATOR
+    $dumpfile(file);
+    $dumpvars(0);
+`endif
+  endfunction;
+`endif
+
+  export "DPI-C" function quit;
+  function quit();
+    $finish;
+  endfunction;
+
+  import "DPI-C" context function void t1rocket_cosim_init();
+  import "DPI-C" context function void t1rocket_cosim_final();
+  initial begin
+    t1rocket_cosim_init();
+    clock = 1'b0;
+    reset = 1'b1;
+  end
+  final begin
+    t1rocket_cosim_final();
+  end
+
+  initial #(100) reset = 1'b0;
+  always #10 clock = ~clock;
+endmodule


### PR DESCRIPTION
**Proposed Design**

This PR proposes we should try move simulation control logic (clock gen, dump wave, watch dog, etc) to `TestDriver.sv`. These features are inherently coupled with simulation platform. For VCS flow, it's best to address these in verilog code.

Current Design:
```verilog
module TestBench; // top module, defined in Chisel
  ClockGen clockGen(.clock, .reset); // inlined in Chisel
endmodule
```

~Proposed Design:~
```
module TestDrvier; // top module, defined in sv
  // clock gen logic
  TestBench tb(.clock, .reset);
endmodule

module TestBench(input clock, input reset); // defined in Chisel
endmodule
```

**Benefits**

- rapid iteration cycle: currently touch everything in ClockGen requires re-elaboration, which is painfully slow.
- ~extensible to Arcilator in the future: I suppose we need a dedicated test driver for arc anyway, it's very unlike to reuse current ClockGen.~

**Future work**: I plan do refacoring of simulation control code, the current code is too messy. This is the first step.

**UPDATE**: After discusssion, we reach consensus that no need to  pull inner ClockGen to outer TestDriver. This PR only change inlined ClockGen to ExtModule.