### PR TITLE
Pass design parameters by verilog parameters

### DIFF
--- a/difftest/Cargo.lock
+++ b/difftest/Cargo.lock
@@ -320,6 +320,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "offline_common"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "num-bigint",
+ "serde",
+ "serde_json",
+ "spike_rs",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "offline_t1emu"
 version = "0.1.0"
 dependencies = [
@@ -327,6 +341,7 @@ dependencies = [
  "clap",
  "libloading",
  "num-bigint",
+ "offline_common",
  "serde",
  "serde_json",
  "spike_rs",
@@ -343,6 +358,7 @@ dependencies = [
  "clap",
  "libloading",
  "num-bigint",
+ "offline_common",
  "serde",
  "serde_json",
  "spike_rs",
@@ -507,10 +523,8 @@ name = "spike_rs"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap",
  "libc",
  "tracing",
- "tracing-subscriber",
  "xmas-elf",
 ]
 

--- a/difftest/Cargo.lock
+++ b/difftest/Cargo.lock
@@ -522,9 +522,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "svdpi"
-version = "0.0.1"
+version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9248c35a9b58d508b60d40b6f5ab8173760b32445d055e90822f57f09b9d0f58"
+checksum = "47897130b3c4134f7c3c924619ef9438dee608b3ad4afb5771fb0a3927b67e53"
 
 [[package]]
 name = "syn"

--- a/difftest/Cargo.toml
+++ b/difftest/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "spike_rs",
     "offline_t1emu",
     "offline_t1rocketemu",
+    "offline_common",
     "dpi_t1emu",
     "dpi_t1rocketemu",
     "dpi_common",

--- a/difftest/Cargo.toml
+++ b/difftest/Cargo.toml
@@ -23,4 +23,4 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "ansi"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 num-bigint = "0.4.6"
-svdpi = "0.0.1"
+svdpi = "0.0.3"

--- a/difftest/default.nix
+++ b/difftest/default.nix
@@ -23,6 +23,7 @@ let
       ./dpi_common
       ./dpi_t1emu
       ./dpi_t1rocketemu
+      ./offline_common
       ./offline_t1emu
       ./offline_t1rocketemu
       ./Cargo.lock
@@ -43,9 +44,6 @@ if (lib.hasPrefix "dpi" moduleType) then
     env = {
       SPIKE_LIB_DIR = "${libspike}/lib";
       SPIKE_INTERFACES_LIB_DIR = "${libspike_interfaces}/lib";
-      DESIGN_VLEN = rtlDesignMetadata.vlen;
-      DESIGN_DLEN = rtlDesignMetadata.dlen;
-      SPIKE_ISA_STRING = rtlDesignMetadata.march;
     };
 
     cargoLock = {

--- a/difftest/dpi_t1emu/src/lib.rs
+++ b/difftest/dpi_t1emu/src/lib.rs
@@ -1,48 +1,5 @@
-use std::path::PathBuf;
-
-use dpi_common::plusarg::PlusArgMatcher;
-
 pub mod dpi;
 pub mod drive;
-
-pub(crate) struct OnlineArgs {
-  /// Path to the ELF file
-  pub elf_file: PathBuf,
-
-  /// Path to the log file
-  pub log_file: Option<PathBuf>,
-
-  /// vlen config
-  pub vlen: u32,
-
-  /// dlen config
-  pub dlen: u32,
-
-  /// ISA config
-  pub set: String,
-
-  // default to TIMEOUT_DEFAULT
-  pub timeout: u64,
-}
-
-const TIMEOUT_DEFAULT: u64 = 1000000;
-
-impl OnlineArgs {
-  pub fn from_plusargs(matcher: &PlusArgMatcher) -> Self {
-    Self {
-      elf_file: matcher.match_("t1_elf_file").into(),
-      log_file: matcher.try_match("t1_log_file").map(|x| x.into()),
-
-      vlen: env!("DESIGN_VLEN").parse().unwrap(),
-      dlen: env!("DESIGN_DLEN").parse().unwrap(),
-      set: env!("SPIKE_ISA_STRING").parse().unwrap(),
-      timeout: matcher
-        .try_match("t1_timeout")
-        .map(|x| x.parse().unwrap())
-        .unwrap_or(TIMEOUT_DEFAULT),
-    }
-  }
-}
 
 // keep in sync with TestBench.verbatimModule
 // the value is measured in simulation time unit

--- a/difftest/dpi_t1rocketemu/src/lib.rs
+++ b/difftest/dpi_t1rocketemu/src/lib.rs
@@ -1,36 +1,6 @@
-use std::path::PathBuf;
-
-use dpi_common::plusarg::PlusArgMatcher;
-
 mod dpi;
 mod drive;
 mod interconnect;
-
-pub(crate) struct OnlineArgs {
-  /// Path to the ELF file
-  pub elf_file: PathBuf,
-
-  /// dlen config
-  pub dlen: u32,
-
-  // default to TIMEOUT_DEFAULT
-  pub timeout: u64,
-}
-
-const TIMEOUT_DEFAULT: u64 = 1000000;
-
-impl OnlineArgs {
-  pub fn from_plusargs(matcher: &PlusArgMatcher) -> Self {
-    Self {
-      elf_file: matcher.match_("t1_elf_file").into(),
-      dlen: env!("DESIGN_DLEN").parse().unwrap(),
-      timeout: matcher
-        .try_match("t1_timeout")
-        .map(|x| x.parse().unwrap())
-        .unwrap_or(TIMEOUT_DEFAULT),
-    }
-  }
-}
 
 // keep in sync with TestBench.verbatimModule
 // the value is measured in simulation time unit

--- a/difftest/offline_common/Cargo.toml
+++ b/difftest/offline_common/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "offline_t1rocketemu"
+name = "offline_common"
 version = "0.1.0"
 edition = "2021"
 
@@ -12,8 +12,4 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 num-bigint = { workspace = true }
 
-libloading = "0.8.1"
-xmas-elf = "0.9.1"
-
 spike_rs = { path = "../spike_rs" }
-offline_common = { path = "../offline_common" }

--- a/difftest/offline_common/src/lib.rs
+++ b/difftest/offline_common/src/lib.rs
@@ -1,0 +1,63 @@
+use std::path::PathBuf;
+
+use clap::Parser;
+use spike_rs::runner::SpikeArgs;
+use tracing::Level;
+use tracing_subscriber::{EnvFilter, FmtSubscriber};
+
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_about = None)]
+pub struct OfflineArgs {
+  /// Path to the ELF file
+  #[arg(long)]
+  pub elf_file: PathBuf,
+
+  /// Path to the log file
+  #[arg(long)]
+  pub log_file: Option<PathBuf>,
+
+  /// Log level: trace, debug, info, warn, error
+  #[arg(long, default_value = "info")]
+  pub log_level: String,
+
+  /// vlen config
+  #[arg(long, default_value = env!("DESIGN_VLEN"))]
+  pub vlen: u32,
+
+  /// dlen config
+  #[arg(long, default_value = env!("DESIGN_DLEN"))]
+  pub dlen: u32,
+
+  /// ISA config
+  #[arg(long, default_value = env!("SPIKE_ISA_STRING"))]
+  pub set: String,
+}
+
+impl OfflineArgs {
+  pub fn to_spike_args(self) -> SpikeArgs {
+    SpikeArgs {
+      elf_file: self.elf_file,
+      log_file: self.log_file,
+      vlen: self.vlen,
+      dlen: self.dlen,
+      set: self.set,
+    }
+  }
+
+  pub fn setup_logger(&self) -> anyhow::Result<()> {
+    // setup log
+    let log_level: Level = self.log_level.parse()?;
+    let global_logger = FmtSubscriber::builder()
+      .with_env_filter(EnvFilter::from_default_env())
+      .with_max_level(log_level)
+      .without_time()
+      .with_target(false)
+      .with_ansi(true)
+      .compact()
+      .finish();
+    tracing::subscriber::set_global_default(global_logger)
+      .expect("internal error: fail to setup log subscriber");
+
+    Ok(())
+  }
+}

--- a/difftest/offline_t1emu/Cargo.toml
+++ b/difftest/offline_t1emu/Cargo.toml
@@ -16,3 +16,4 @@ libloading = "0.8.1"
 xmas-elf = "0.9.1"
 
 spike_rs = { path = "../spike_rs" }
+offline_common = { path = "../offline_common" }

--- a/difftest/offline_t1emu/src/main.rs
+++ b/difftest/offline_t1emu/src/main.rs
@@ -9,6 +9,7 @@ use std::{
 use anyhow::Context as _;
 use clap::Parser;
 use json_events::JsonEvents;
+use offline_common::OfflineArgs;
 use tracing::info;
 
 use spike_rs::runner::*;
@@ -35,9 +36,11 @@ fn run_spike(args: &SpikeArgs) -> anyhow::Result<()> {
 
 fn main() -> anyhow::Result<()> {
   // parse args
-  let args = SpikeArgs::parse();
+  let args = OfflineArgs::parse();
 
   args.setup_logger()?;
+
+  let args = args.to_spike_args();
 
   match &args.log_file {
     None => {

--- a/difftest/offline_t1rocketemu/src/main.rs
+++ b/difftest/offline_t1rocketemu/src/main.rs
@@ -9,6 +9,7 @@ use std::{
 use anyhow::Context as _;
 use clap::Parser;
 use json_events::JsonEvents;
+use offline_common::OfflineArgs;
 use tracing::info;
 
 use spike_rs::runner::{SpikeArgs, SpikeRunner};
@@ -35,9 +36,11 @@ fn run_spike(args: &SpikeArgs) -> anyhow::Result<()> {
 
 fn main() -> anyhow::Result<()> {
   // parse args
-  let args = SpikeArgs::parse();
+  let args = OfflineArgs::parse();
 
   args.setup_logger()?;
+
+  let args = args.to_spike_args();
 
   match &args.log_file {
     None => {

--- a/difftest/spike_rs/Cargo.toml
+++ b/difftest/spike_rs/Cargo.toml
@@ -5,9 +5,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = { workspace = true }
-clap = { workspace = true }
 tracing = { workspace = true }
-tracing-subscriber = { workspace = true }
 
 libc = "0.2.155"
 xmas-elf = "0.9.1"

--- a/difftest/spike_rs/src/runner.rs
+++ b/difftest/spike_rs/src/runner.rs
@@ -1,8 +1,6 @@
-use clap::Parser;
 use std::collections::VecDeque;
 use std::path::{Path, PathBuf};
-use tracing::{debug, Level};
-use tracing_subscriber::{EnvFilter, FmtSubscriber};
+use tracing::debug;
 
 use crate::spike_event::SpikeEvent;
 use crate::util::load_elf;
@@ -49,31 +47,20 @@ pub struct SpikeRunner {
   pub frf_board: Vec<Option<u32>>,
 }
 
-#[derive(Parser, Debug)]
-#[command(author, version, about, long_about = None)]
 pub struct SpikeArgs {
   /// Path to the ELF file
-  #[arg(long)]
   pub elf_file: PathBuf,
 
   /// Path to the log file
-  #[arg(long)]
   pub log_file: Option<PathBuf>,
 
-  /// Log level: trace, debug, info, warn, error
-  #[arg(long, default_value = "info")]
-  pub log_level: String,
-
   /// vlen config
-  #[arg(long, default_value = env!("DESIGN_VLEN"))]
   pub vlen: u32,
 
   /// dlen config
-  #[arg(long, default_value = env!("DESIGN_DLEN"))]
   pub dlen: u32,
 
   /// ISA config
-  #[arg(long, default_value = env!("SPIKE_ISA_STRING"))]
   pub set: String,
 }
 
@@ -81,23 +68,6 @@ impl SpikeArgs {
   fn to_spike_c_handler(&self) -> Box<Spike> {
     let lvl = "M";
     Spike::new(&self.set, lvl, (self.dlen / 32) as usize, MEM_SIZE)
-  }
-
-  pub fn setup_logger(&self) -> anyhow::Result<()> {
-    // setup log
-    let log_level: Level = self.log_level.parse()?;
-    let global_logger = FmtSubscriber::builder()
-      .with_env_filter(EnvFilter::from_default_env())
-      .with_max_level(log_level)
-      .without_time()
-      .with_target(false)
-      .with_ansi(true)
-      .compact()
-      .finish();
-    tracing::subscriber::set_global_default(global_logger)
-      .expect("internal error: fail to setup log subscriber");
-
-    Ok(())
   }
 }
 

--- a/profiler/default.nix
+++ b/profiler/default.nix
@@ -6,7 +6,7 @@
 rustPlatform.buildRustPackage {
   src = ./.;
   name = "profiler";
-  
+
   cargoLock = {
     lockFile = ./Cargo.lock;
   };

--- a/t1/src/T1.scala
+++ b/t1/src/T1.scala
@@ -143,6 +143,8 @@ case class T1Parameter(
     vlen.toInt
   }.get
 
+  def spikeMarch: String = s"rv32gc_${extensions.mkString("_").toLowerCase}"
+
   val allInstructions: Seq[Instruction] = {
     org.chipsalliance.rvdecoderdb
       .instructions(org.chipsalliance.rvdecoderdb.extractResource(getClass.getClassLoader))
@@ -392,7 +394,7 @@ class T1(val parameter: T1Parameter)
   omInstance.vlenIn       := Property(parameter.vLen)
   omInstance.dlenIn       := Property(parameter.dLen)
   omInstance.extensionsIn := Property(parameter.extensions)
-  omInstance.marchIn      := Property(s"rv32gc_${parameter.extensions.mkString("_").toLowerCase}")
+  omInstance.marchIn      := Property(parameter.spikeMarch)
 
   /** the LSU Module */
 

--- a/t1emu/src/TestBench.scala
+++ b/t1emu/src/TestBench.scala
@@ -39,12 +39,19 @@ class TestBench(val parameter: T1Parameter)
   val om:         Property[ClassType]   = IO(Output(Property[omType.Type]()))
   om := omInstance.getPropertyReference
 
-  val verbatimModule = Module(new ExtModule {
-
-    override def desiredName = "VerbatimModule"
-    val clock                = IO(Output(Bool()))
-    val reset                = IO(Output(Bool()))
-  })
+  val verbatimModule         = Module(
+    new ExtModule(
+      Map(
+        "T1_VLEN"      -> parameter.vLen,
+        "T1_DLEN"      -> parameter.dLen,
+        "T1_SPIKE_ISA" -> parameter.spikeMarch
+      )
+    ) {
+      override def desiredName = "VerbatimModule"
+      val clock                = IO(Output(Bool()))
+      val reset                = IO(Output(Bool()))
+    }
+  )
   def clock                  = verbatimModule.clock.asClock
   def reset                  = verbatimModule.reset
   override def implicitClock = verbatimModule.clock.asClock

--- a/t1emu/vsrc/VerbatimModule.sv
+++ b/t1emu/vsrc/VerbatimModule.sv
@@ -1,18 +1,27 @@
-module VerbatimModule(output reg clock, output reg reset);
+module VerbatimModule #(
+  parameter integer T1_DLEN,
+  parameter integer T1_VLEN,
+  parameter string T1_SPIKE_ISA
+)(
+  output reg clock,
+  output reg reset
+);
 
   // This module contains everything we can not represent in Chisel currently,
   // including clock gen, plusarg parsing, sim control, etc
   //
   // plusargs: "T" denotes being present only if trace is enabled 
-  //   +t1_elf_file       (required)   path to elf file, parsed in DPI side
+  //   +t1_elf_file       (required)   path to elf file
   //   +t1_wave_path      (required T) path to wave dump file
-  //   +t1_timeout        (optional)   max cycle between two V inst retire, parsed in DPI side
+  //   +t1_timeout        (optional)   max cycle between two V inst retire
   //   +t1_global_timeout (optional)   max cycle for whole simulation, for debug only
   //   +t1_dump_start     (optional T) cycle when dump starts, by default it's simulation start, for debug only
   //   +t1_dump_end       (optional T) cycle when dump ends, by default is's simulation end, for debug only
 
   longint unsigned cycle = 0;
   longint unsigned global_timeout = 0;
+  longint unsigned dpi_timeout = 1000000;
+  string elf_file;
 `ifdef T1_ENABLE_TRACE
   longint unsigned dump_start = 0;
   longint unsigned dump_end = 0;
@@ -44,7 +53,13 @@ module VerbatimModule(output reg clock, output reg reset);
   endfunction
 `endif
 
-  import "DPI-C" context function void t1_cosim_init();
+  import "DPI-C" context function void t1_cosim_init(
+    string elf_file,
+    int dlen,
+    int vlen,
+    string spike_isa
+  );
+  import "DPI-C" context function void t1_cosim_set_timeout(longint unsigned timeout);
   import "DPI-C" context function void t1_cosim_final();
   import "DPI-C" context function byte unsigned t1_cosim_watchdog();
 
@@ -57,9 +72,14 @@ module VerbatimModule(output reg clock, output reg reset);
     $value$plusargs("t1_dump_end=%d", dump_end);
     $value$plusargs("t1_wave_path=%s", wave_path);
   `endif
+    $value$plusargs("t1_elf_file=%s", elf_file);
+    $value$plusargs("t1_timeout=%d", dpi_timeout);
     $value$plusargs("t1_global_timeout=%d", global_timeout);
 
-    t1_cosim_init();
+    if (elf_file.len() == 0) $fatal(1, "+t1_elf_file must be set");
+
+    t1_cosim_init(elf_file, T1_DLEN, T1_VLEN, T1_SPIKE_ISA);
+    t1_cosim_set_timeout(dpi_timeout);
 
   `ifdef T1_ENABLE_TRACE
     if (dump_start == 0) begin

--- a/t1rocketemu/src/TestBench.scala
+++ b/t1rocketemu/src/TestBench.scala
@@ -39,13 +39,21 @@ class TestBench(val parameter: T1RocketTileParameter)
   val om:         Property[ClassType]   = IO(Output(Property[omType.Type]()))
   om := omInstance.getPropertyReference
 
-  val verbatimModule         = Module(new ExtModule {
-    override def desiredName = "VerbatimModule"
-    val clock                = IO(Output(Bool()))
-    val reset                = IO(Output(Bool()))
-    val initFlag             = IO(Output(Bool()))
-    val idle                 = IO(Input(Bool()))
-  })
+  val verbatimModule         = Module(
+    new ExtModule(
+      Map(
+        "T1_VLEN"      -> parameter.vLen,
+        "T1_DLEN"      -> parameter.dLen,
+        "T1_SPIKE_ISA" -> parameter.t1Parameter.spikeMarch
+      )
+    ) {
+      override def desiredName = "VerbatimModule"
+      val clock                = IO(Output(Bool()))
+      val reset                = IO(Output(Bool()))
+      val initFlag             = IO(Output(Bool()))
+      val idle                 = IO(Input(Bool()))
+    }
+  )
   def clock                  = verbatimModule.clock.asClock
   def reset                  = verbatimModule.reset
   def initFlag               = verbatimModule.initFlag


### PR DESCRIPTION
Today DPI get deisgn through a very unintuitive way:
Chisel -> mlirbc -> omreader -> nix -> env variables -> DPI

After this PR, the information flow follows the patterns below:
- Design parameters: Chisel -> VerbatimModule(parameters) -> DPI
- Runtime parameters: VerbatimModule(plusargs) -> DPI

We may still use omreader to pass information to other components. Howerver, for DPI, I believe the way taken is this PR is much more intuitive.