### PR TITLE
[nix] Add vcs sim profile flow

### DIFF
--- a/nix/pkgs/snps-fhs-env.nix
+++ b/nix/pkgs/snps-fhs-env.nix
@@ -78,6 +78,7 @@ lockedPkgs.buildFHSEnv {
     nssmdns
     fontconfig
     numactl
+    python3
     (krb5.overrideAttrs rec {
       version = "1.18.2";
       src = fetchurl {

--- a/nix/t1/conversion/sv-to-vcs-simulator.nix
+++ b/nix/t1/conversion/sv-to-vcs-simulator.nix
@@ -26,6 +26,11 @@ stdenv.mkDerivation rec {
 
   dontUnpack = true;
 
+  # VCS simulation profiling
+  # This is a debug feature, thus intentionally not exposed
+  # Enable it by changing line below to 'true'
+  enableProfile = false;
+
   vcsArgs = [
     "-sverilog"
     "-full64"
@@ -55,6 +60,9 @@ stdenv.mkDerivation rec {
     "+define+T1_ENABLE_TRACE"
     "-debug_access+pp+dmptf+thread"
     "-kdb=common_elab,hgldd_all"
+  ]
+  ++ lib.optionals enableProfile [
+    "-simprofile"
   ]
   ++ vcsLinkLibs;
 

--- a/nix/t1/run/default.nix
+++ b/nix/t1/run/default.nix
@@ -16,10 +16,9 @@ let
   runVerilatorEmu = callPackage ./run-verilator-emu.nix { };
   runVCSEmu_ = callPackage ./run-vcs-emu.nix { };
   runFsdb2vcd = callPackage ./run-fsdb2vcd.nix { };
-  runVCSEmu = emulator: runVCSEmu_ { inherit emulator; };
-  runVCSEmuRT = emulator: runVCSEmu_ {
+  runVCSEmu = emulator: runVCSEmu_ {
     inherit emulator;
-    dpilib = vcs-dpi-lib;
+    dpilib = if emulator.isRuntimeLoad then vcs-dpi-lib else null;
   };
 
   # cases is now { mlir = { hello = ...; ...  }; ... }
@@ -39,7 +38,7 @@ let
           innerMapper = caseName: case: {
             verilator-emu = runVerilatorEmu verilator-emu case;
             verilator-emu-trace = runVerilatorEmu verilator-emu-trace case;
-            vcs-emu = runVCSEmuRT vcs-emu-rtlink case;
+            vcs-emu = runVCSEmu vcs-emu-rtlink case;
             vcs-emu-cover = runVCSEmu vcs-emu-cover case;
             vcs-emu-trace = runVCSEmu vcs-emu-trace case;
             vcs-prof-vcd = runFsdb2vcd (runVCSEmu vcs-emu-trace case);


### PR DESCRIPTION
Profile vcs simulation time

Since we do not want to cache prof results anyway, we couldn't use 'nix build'. The flow is a bit distorted.

Usage:
1. modify `enableProfile = true` in 'sv-to-vcs-simulator.nix'
2. `nix run --impure .#t1.rookidee.t1rocketemu.run.asm.mmm.vcs-emu.profile', for example
3. open 'profileReport.html' in current workdir