### PR TITLE
[nix] remove unused coverage

### DIFF
--- a/nix/t1/conversion/sv-to-vcs-simulator.nix
+++ b/nix/t1/conversion/sv-to-vcs-simulator.nix
@@ -48,7 +48,7 @@ stdenv.mkDerivation rec {
   ]
   ++ lib.optionals enableCover [
     "-cm"
-    "line+cond+fsm+tgl+branch+assert"
+    "assert"
     "-cm_dir"
     "./cm"
   ]


### PR DESCRIPTION
Since we only use SVA functional cover, we do not need to collect coverage for anything else.

It brings huge speedup for vcs-emu-cover. Here is result for once case

- no cover: 144s
- cover(master): 320s
- cover(this PR): 148s