### PR TITLE
Fix vrf scoreboard

### DIFF
--- a/difftest/offline_t1emu/src/difftest.rs
+++ b/difftest/offline_t1emu/src/difftest.rs
@@ -40,9 +40,9 @@ pub fn diff(runner: &mut SpikeRunner, event: &JsonEvents) -> anyhow::Result<()> 
       runner.cycle = *cycle;
       runner.check_rd(&CheckRdEvent { data: *data, issue_idx: *issue_idx, cycle: *cycle })
     }
-    JsonEvents::VrfScoreboardReport { count, issue_idx, cycle } => {
+    JsonEvents::VrfScoreboard { count, issue_idx, cycle } => {
       runner.cycle = *cycle;
-      runner.vrf_scoreboard_report(&VrfScoreboardReportEvent {
+      runner.vrf_scoreboard(&VrfScoreboardEvent {
         count: *count,
         issue_idx: *issue_idx,
         cycle: *cycle,

--- a/difftest/offline_t1emu/src/json_events.rs
+++ b/difftest/offline_t1emu/src/json_events.rs
@@ -333,8 +333,8 @@ impl JsonEventRunner for SpikeRunner {
         se.vrf_access_record.retired_writes,
         se.describe_insn()
       );
-    } else {
-      panic!("[{cycle}] VrfScoreboard: cannot find se with instruction issue_idx={issue_idx}");
+    } else if count != 0 {
+      panic!("[{cycle}] VrfScoreboard: cannot find se with instruction issue_idx={issue_idx}, count={count}");
     }
 
     if let Some(issue_idx) = should_retire {

--- a/difftest/offline_t1rocketemu/src/json_events.rs
+++ b/difftest/offline_t1rocketemu/src/json_events.rs
@@ -383,7 +383,7 @@ impl JsonEventRunner for SpikeRunner {
       if let Some(unretired_writes) = se.vrf_access_record.unretired_writes {
         assert!(
           unretired_writes > 0,
-          "[{}] unretired_writes should be greater than 0, issue_idx={} ({})",
+          "[{}] VrfWrite: unretired_writes should be greater than 0, issue_idx={} ({})",
           vrf_write.cycle,
           vrf_write.issue_idx,
           se.describe_insn()
@@ -403,8 +403,8 @@ impl JsonEventRunner for SpikeRunner {
           assert_eq!(
             record.byte,
             written_byte,
-            "[{}] {offset}th byte incorrect ({:#02x} record != {written_byte:#02x} written) \
-              for vrf write (lane={}, vd={}, offset={}, mask={}, data={:x?}) \
+            "[{}] VrfWrite: {offset}th byte incorrect ({:#02x} record != {written_byte:#02x} written) \
+              (lane={}, vd={}, offset={}, mask={}, data={:x?}) \
               issue_idx={} [vrf_idx={}] (disasm: {}, pc: {:#x}, bits: {:#x})",
             vrf_write.cycle,
             record.byte,
@@ -422,7 +422,7 @@ impl JsonEventRunner for SpikeRunner {
           record.executed = true;
         } else {
           debug!(
-            "[{}] cannot find vrf write record, maybe not changed (lane={}, vd={}, idx={}, offset={}, mask={}, data={:x?})",
+            "[{}] VrfWrite: cannot find vrf write record, maybe not changed (lane={}, vd={}, idx={}, offset={}, mask={}, data={:x?})",
             vrf_write.cycle,
             vrf_write.lane,
             vrf_write.vd,
@@ -435,7 +435,7 @@ impl JsonEventRunner for SpikeRunner {
       })
     } else {
       info!(
-        "[{cycle}] RecordRFAccess: rtl detect vrf write on lane={}, vd={} \
+        "[{cycle}] VrfWrite: rtl detect vrf write on lane={}, vd={} \
         with no matched se (issue_idx={}), \
         maybe from committed load insn",
         vrf_write.lane, vrf_write.vd, vrf_write.issue_idx
@@ -466,7 +466,7 @@ impl JsonEventRunner for SpikeRunner {
           let data_byte = *data.get(offset).unwrap_or(&0);
           let mem_write =
             se.mem_access_record.all_writes.get_mut(&byte_addr).unwrap_or_else(|| {
-              panic!("[{cycle}] cannot find mem write of byte_addr {byte_addr:#x}")
+              panic!("[{cycle}] MemoryWrite: cannot find mem write of byte_addr {byte_addr:#x}")
             });
           let single_mem_write_val = mem_write.writes[mem_write.num_completed_writes].val;
           mem_write.num_completed_writes += 1;
@@ -475,7 +475,7 @@ impl JsonEventRunner for SpikeRunner {
       return Ok(());
     }
 
-    panic!("[{cycle}] cannot find se with instruction lsu_idx={lsu_idx}")
+    panic!("[{cycle}] MemoryWrite: cannot find se with instruction lsu_idx={lsu_idx}")
   }
 
   fn vrf_scoreboard(&mut self, vrf_scoreboard: &VrfScoreboardEvent) -> anyhow::Result<()> {
@@ -488,7 +488,7 @@ impl JsonEventRunner for SpikeRunner {
     if let Some(se) = self.commit_queue.iter_mut().rev().find(|se| se.issue_idx == issue_idx) {
       assert!(
         se.vrf_access_record.retired_writes <= count,
-        "[{cycle}] retired_writes({}) should be less than count({count}), issue_idx={issue_idx} ({})",
+        "[{cycle}] VrfScoreboard: retired_writes({}) should be less than count({count}), issue_idx={issue_idx} ({})",
         se.vrf_access_record.retired_writes, se.describe_insn()
       );
 
@@ -500,12 +500,12 @@ impl JsonEventRunner for SpikeRunner {
       se.vrf_access_record.unretired_writes = Some(count - se.vrf_access_record.retired_writes);
 
       info!(
-        "[{cycle}] VrfScoreboardReport: count={count}, issue_idx={issue_idx}, retired={} ({})",
+        "[{cycle}] VrfScoreboard: count={count}, issue_idx={issue_idx}, retired={} ({})",
         se.vrf_access_record.retired_writes,
         se.describe_insn()
       );
     } else {
-      panic!("[{cycle}] cannot find se with instruction issue_idx={issue_idx}");
+      panic!("[{cycle}] VrfScoreboard: cannot find se with instruction issue_idx={issue_idx}");
     }
 
     if let Some(issue_idx) = should_retire {
@@ -533,7 +533,7 @@ impl JsonEventRunner for SpikeRunner {
 
     let se =
       self.commit_queue.iter_mut().find(|se| se.issue_idx == issue_idx).unwrap_or_else(|| {
-        panic!("[{cycle}] cannot find se with instruction issue_idx={issue_idx}")
+        panic!("[{cycle}] CheckRd: cannot find se with instruction issue_idx={issue_idx}")
       });
 
     info!("[{cycle}] CheckRd: issue_idx={issue_idx}, data={data:x?}");

--- a/difftest/offline_t1rocketemu/src/json_events.rs
+++ b/difftest/offline_t1rocketemu/src/json_events.rs
@@ -504,8 +504,8 @@ impl JsonEventRunner for SpikeRunner {
         se.vrf_access_record.retired_writes,
         se.describe_insn()
       );
-    } else {
-      panic!("[{cycle}] VrfScoreboard: cannot find se with instruction issue_idx={issue_idx}");
+    } else if count != 0 {
+      panic!("[{cycle}] VrfScoreboard: cannot find se with instruction issue_idx={issue_idx}, count={count}");
     }
 
     if let Some(issue_idx) = should_retire {

--- a/t1emu/src/TestBench.scala
+++ b/t1emu/src/TestBench.scala
@@ -234,7 +234,7 @@ class TestBench(val parameter: T1Parameter)
     scoreboard.bits := scoreboard.bits + PopCount(writeEnq)
     when(scoreboard.valid && !instructionValid(tag)) {
       printf(
-        cf"""{"event":"VrfScoreboardReport","count":${scoreboard.bits},"issue_idx":${tag},"cycle":${simulationTime}}\n"""
+        cf"""{"event":"VrfScoreboard","count":${scoreboard.bits},"issue_idx":${tag},"cycle":${simulationTime}}\n"""
       )
       scoreboard.valid := false.B
     }


### PR DESCRIPTION
This PR:
- Aligned some behaviors between t1 and t1rocket in offline difftest.
- Adjusted some output logs in offline difftest.
- Fixed the issue in offline difftest where `count == 0` caused a conflict with writing rd. This fix might be somewhat rough.