### PR TITLE
[memory] drop DDR and use SRAM only

### DIFF
--- a/difftest/dpi_t1rocketemu/src/interconnect.rs
+++ b/difftest/dpi_t1rocketemu/src/interconnect.rs
@@ -195,13 +195,10 @@ impl AddressSpace {
 /// Memory map:
 /// - 0x0400_0000 - 0x0600_0000 : framebuffer
 /// - 0x1000_0000 - 0x1000_1000 : simctrl
-/// - 0x2000_0000 - 0xc000_0000 : ddr
-/// - 0xc000_0000 - 0xc040_0000 : sram
+/// - 0x2000_0000 - 0xc000_0000 : sram
 pub fn create_emu_addrspace() -> (AddressSpace, ExitFlagRef) {
-  const DDR_BASE: u32 = 0x2000_0000;
-  const DDR_SIZE: u32 = 0xa000_0000;
-  const SRAM_BASE: u32 = 0xc000_0000;
-  const SRAM_SIZE: u32 = 0x0100_0000;
+  const SRAM_BASE: u32 = 0x2000_0000;
+  const SRAM_SIZE: u32 = 0xa000_0000;
 
   const SIMCTRL_BASE: u32 = 0x1000_0000;
   const SIMCTRL_SIZE: u32 = 0x0000_1000; // one page
@@ -211,7 +208,6 @@ pub fn create_emu_addrspace() -> (AddressSpace, ExitFlagRef) {
   let exit_flag = ExitFlagRef::new();
 
   let devices = vec![
-    RegularMemory::with_size(DDR_SIZE).with_addr(DDR_BASE, DDR_SIZE),
     RegularMemory::with_size(SRAM_SIZE).with_addr(SRAM_BASE, SRAM_SIZE),
     FrameBuffer::new().with_addr(DISPLAY_BASE, DISPLAY_SIZE),
     SimCtrl::new(exit_flag.clone()).with_addr(SIMCTRL_BASE, SIMCTRL_SIZE),

--- a/tests/codegen/default.nix
+++ b/tests/codegen/default.nix
@@ -36,14 +36,8 @@ let
             -configfile ${riscv-vector-test}/configs/${rawCaseName}.toml \
             -outputfile $pname.S
 
-          # temporary fix, to be extended later
-          if $CC $pname.S -T ${linkerScript} $includeArgs -o $pname.elf ; then
-            echo "link with 4M SRAM succeded"
-          else
-            echo "link with 4M SRAM failed, use DDR instead"
-            sed 's/>SRAM/>DDR/' ${linkerScript} > t1-ddr.ld
-            $CC $pname.S -T t1-ddr.ld $includeArgs -o $pname.elf
-          fi
+          $CC $pname.S -T ${linkerScript} $includeArgs -o $pname.elf
+          echo "Complilation done"
 
           runHook postBuild
         '';

--- a/tests/t1.ld
+++ b/tests/t1.ld
@@ -1,11 +1,16 @@
 OUTPUT_ARCH(riscv)
 ENTRY(_start)
 
+/* The "SRAM" here should be distinguish from SOC's SRAM. The SOC SRAM is a 2560MB memory scratch pad.
+ * And the "SRAM" here is for separating the address space to avoid conflict read & write.
+ *
+ * This memory region should be codegen from stuff like device tree.
+ */
 MEMORY {
   SCALAR (RWX) : ORIGIN = 0x20000000, LENGTH = 512M /* put first to set it as default */
   MMIO   (RW)  : ORIGIN = 0x00000000, LENGTH = 512M
-  DDR    (RW)  : ORIGIN = 0x40000000, LENGTH = 2048M
-  SRAM   (RW)  : ORIGIN = 0xc0000000, LENGTH = 16M /* TODO: read from config */
+  HEAP   (RW)  : ORIGIN = 0x40000000, LENGTH = 1024M
+  SRAM   (RW)  : ORIGIN = 0x60000000, LENGTH = 1024M
 }
 
 SECTIONS {
@@ -31,5 +36,5 @@ SECTIONS {
   .vbss (TYPE = SHT_NOBITS) : { *(.vbss .vbss.*) } >SRAM
 
   __stacktop = ORIGIN(SCALAR) + LENGTH(SCALAR);  /* put stack on the top of SCALAR */
-  __heapbegin = ORIGIN(DDR);  /* put heap on the begin of DDR */
+  __heapbegin = ORIGIN(HEAP);  /* put heap on the begin of DDR */
 }


### PR DESCRIPTION
There is no need for a single DDR memory region in SOC. This commit drop
the DDR memory in simulator and realloc the memory address space in
linker script.

Signed-off-by: Avimitin <dev@avimit.in>
