### PR TITLE
[ci] fix the missing building target modification in vcs ci

### DIFF
--- a/.github/workflows/t1rocket.yml
+++ b/.github/workflows/t1rocket.yml
@@ -43,7 +43,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: "Build vcs emulator"
         run: |
-          nix build '.#t1.${{ matrix.config }}.${{ env.EMU_TOP }}.vcs-emu' --impure --no-link
+          nix build '.#t1.${{ matrix.config }}.${{ env.EMU_TOP }}.vcs-emu-cover' --impure --no-link
       - name: "Build all testcases"
         run: |
           nix build ".#t1.${{ matrix.config }}.${{ env.EMU_TOP }}.cases._all" --max-jobs auto --no-link --cores 64

--- a/script/ci/src/Main.scala
+++ b/script/ci/src/Main.scala
@@ -164,7 +164,6 @@ object Main:
 
       val testAttr       = emuLib.toLowerCase() match
         case "verilator" => s".#t1.$config.$top.run.$caseName.verilator-emu"
-        // TODO: should not be cover for every test case
         case "vcs"       => s".#t1.$config.$top.run.$caseName.vcs-emu-cover"
         case _           => Logger.fatal(s"Invalid test type ${emuLib}")
       val testResultPath =


### PR DESCRIPTION
vcs ci now only runs vcs-emu-cover, so building vcs-emu is unnecessary