### PR TITLE
Fix t1rocketemu for verilator build

### DIFF
--- a/t1rocketemu/src/AXI4SlaveAgent.scala
+++ b/t1rocketemu/src/AXI4SlaveAgent.scala
@@ -151,6 +151,7 @@ class AXI4SlaveAgent(parameter: AXI4SlaveAgentParameter)
         RawClockedVoidFunctionCall(s"axi_write_${parameter.name}")(
           io.clock,
           when.cond && !io.gateWrite,
+          io.reset.asTypeOf(UInt(64.W)),
           io.channelId,
           parameter.axiParameter.dataWidth.U(64.W),
           // handle AW and W at same beat.
@@ -198,6 +199,7 @@ class AXI4SlaveAgent(parameter: AXI4SlaveAgentParameter)
       )(
         io.clock,
         !io.gateRead && arFire,
+        io.reset.asTypeOf(UInt(64.W)),
         io.channelId,
         parameter.axiParameter.dataWidth.U(64.W),
         channel.ARID.asTypeOf(UInt(64.W)),


### PR DESCRIPTION
The root cause is clocked dpi call in chisel behave as if a DFF, but it has no way to react to reset signal.

Since we currently only use sync reset, we could actually emulate it in DPI side. reset is passed as an additional parameter to DPI and DPI could set return value to zero when reset, effectively clear the register when reset is asserted.

Note in AXI read, the DPI return register has no control signal. Thus we just leave the content undetermined, to make DPI code cleaner. 