### PR TITLE
[nix] seperate verilating and linking for better caching

### DIFF
--- a/nix/t1/conversion/link-verilator-with-dpi.nix
+++ b/nix/t1/conversion/link-verilator-with-dpi.nix
@@ -34,6 +34,6 @@ stdenv.mkDerivation (rec {
   '';
 
   passthru = {
-    enableTrace = verilatorLib.enableTrace;
+    inherit (verilatorLib) enableTrace;
   };
 })

--- a/nix/t1/conversion/link-verilator-with-dpi.nix
+++ b/nix/t1/conversion/link-verilator-with-dpi.nix
@@ -1,0 +1,39 @@
+{ lib
+, stdenv
+, zlib
+}:
+
+{ mainProgram
+, verilatorLib
+, dpiLibs
+}:
+
+assert lib.assertMsg (builtins.typeOf dpiLibs == "list") "dpiLibs should be a list of file path";
+
+stdenv.mkDerivation (rec {
+  name = mainProgram;
+  inherit mainProgram;
+
+  dontUnpack = true;
+
+  propagatedBuildInputs = [ zlib ];
+
+  ccArgs = [
+    "${verilatorLib}/lib/libV${verilatorLib.topModule}.a"
+  ]
+  ++ dpiLibs
+  ++ [
+    "${verilatorLib}/lib/libverilated.a"
+    "-lz"
+  ];
+
+  buildCommand = ''
+    mkdir -p $out/bin
+
+    $CXX -o $out/bin/$mainProgram ${lib.escapeShellArgs ccArgs}
+  '';
+
+  passthru = {
+    enableTrace = verilatorLib.enableTrace;
+  };
+})

--- a/nix/t1/default.nix
+++ b/nix/t1/default.nix
@@ -99,6 +99,8 @@ lib.makeScope newScope
     # * verilatorArgs: Final arguments that pass to the verilator.
     sv-to-verilator-emulator = lib.makeOverridable (t1Scope.callPackage ./conversion/sv-to-verilator-emulator.nix { stdenv = moldStdenv; });
 
+    link-verilator-with-dpi = lib.makeOverridable (t1Scope.callPackage ./conversion/link-verilator-with-dpi.nix { stdenv = moldStdenv; });
+
     # sv-to-vcs-simulator :: { mainProgram :: String, rtl :: Derivation, enableTrace :: Bool, vcsLinkLibs :: List<String> } -> Derivation
     #
     # sv-to-vcs-simulator will compile the given rtl, link with path specified in vcsLinksLibs to produce a VCS emulator.

--- a/nix/t1/t1.nix
+++ b/nix/t1/t1.nix
@@ -133,10 +133,9 @@ forEachTop (topName: generator: self: {
     verilatorLib = self.verilator-emu-lib;
     dpiLibs = [ "${self.verilator-dpi-lib}/lib/libdpi_${topName}.a" ];
   };
-  verilator-emu-trace = t1Scope.link-verilator-with-dpi {
+  verilator-emu-trace = self.verilator-emu.override {
     mainProgram = "${topName}-verilated-trace-simulator";
     verilatorLib = self.verilator-emu-trace-lib;
-    dpiLibs = [ "${self.verilator-dpi-lib}/lib/libdpi_${topName}.a" ];
   };
 
   # ---------------------------------------------------------------------------------

--- a/nix/t1/t1.nix
+++ b/nix/t1/t1.nix
@@ -117,16 +117,26 @@ forEachTop (topName: generator: self: {
     moduleType = "dpi_${topName}";
   };
 
-  verilator-emu = t1Scope.sv-to-verilator-emulator {
-    mainProgram = "${topName}-verilated-simulator";
+  verilator-emu-lib = t1Scope.sv-to-verilator-emulator {
+    mainProgram = "${topName}-verilated-lib";
     topModule = "TestBench";
     rtl = self.rtl;
     vsrc = lib.filesystem.listFilesRecursive self.clean-vsrc.outPath;
-    extraVerilatorArgs = [ "${self.verilator-dpi-lib}/lib/libdpi_${topName}.a" ];
   };
-  verilator-emu-trace = self.verilator-emu.override {
+  verilator-emu-trace-lib = self.verilator-emu-lib.override {
     enableTrace = true;
+    mainProgram = "${topName}-verilated-trace-lib";
+  };
+
+  verilator-emu = t1Scope.link-verilator-with-dpi {
+    mainProgram = "${topName}-verilated-simulator";
+    verilatorLib = self.verilator-emu-lib;
+    dpiLibs = [ "${self.verilator-dpi-lib}/lib/libdpi_${topName}.a" ];
+  };
+  verilator-emu-trace = t1Scope.link-verilator-with-dpi {
     mainProgram = "${topName}-verilated-trace-simulator";
+    verilatorLib = self.verilator-emu-trace-lib;
+    dpiLibs = [ "${self.verilator-dpi-lib}/lib/libdpi_${topName}.a" ];
   };
 
   # ---------------------------------------------------------------------------------


### PR DESCRIPTION
To cache better, the build of verilator-emu is split into 2 steps:

1. build verilated lib.
2. link verilated lib with dpi lib, get the final executable.

The advantage is that change of dpi code will not invalidate verilated lib