### PR TITLE
[nix] add custom bundler

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -18,6 +18,30 @@
         "type": "github"
       }
     },
+    "nix-bundle": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "utils": [
+          "flake-utils"
+        ]
+      },
+      "locked": {
+        "lastModified": 1738732643,
+        "narHash": "sha256-tC+W41SxDmjggPW6PEByFCv0uRLPjxRI8YMSO4q2/Ks=",
+        "owner": "Avimitin",
+        "repo": "nix-bundle",
+        "rev": "bbeec7617e8a6ccc0908197ee0ca177c5d424315",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Avimitin",
+        "ref": "pname-fix",
+        "repo": "nix-bundle",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1725634671,
@@ -53,6 +77,7 @@
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
+        "nix-bundle": "nix-bundle",
         "nixpkgs": "nixpkgs",
         "nixpkgs-for-circt": "nixpkgs-for-circt"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -5,9 +5,14 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     nixpkgs-for-circt.url = "github:NixOS/nixpkgs/nixos-unstable-small";
     flake-utils.url = "github:numtide/flake-utils";
+    nix-bundle = {
+      url = "github:Avimitin/nix-bundle/pname-fix";
+      inputs.nixpkgs.follows = "nixpkgs";
+      inputs.utils.follows = "flake-utils";
+    };
   };
 
-  outputs = { self, nixpkgs, flake-utils, nixpkgs-for-circt }@inputs:
+  outputs = { self, nixpkgs, flake-utils, nixpkgs-for-circt, nix-bundle }@inputs:
     let
       overlay = import ./nix/overlay.nix { inherit self; };
     in
@@ -29,6 +34,10 @@
             };
           };
           formatter = pkgs.nixpkgs-fmt;
+          bundlers = rec {
+            default = toArx;
+            toArx = nix-bundle.bundlers.${system}.nix-bundle;
+          };
         }
       )
     // { inherit inputs; overlays.default = overlay; };


### PR DESCRIPTION
Most of our derivation definitions have no pname attribute, and official
bundlers doesn't support bundle those derivations. This commit add my
fork as input to fix this issue. Users can run
`nix bundle --bundlers . <attribute>` to bundle a derivation.
