### PR TITLE
[nix]: rename add-determinism to add-det

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -235,11 +235,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1747744144,
-        "narHash": "sha256-W7lqHp0qZiENCDwUZ5EX/lNhxjMdNapFnbErcbnP11Q=",
+        "lastModified": 1757745802,
+        "narHash": "sha256-hLEO2TPj55KcUFUU1vgtHE9UEIOjRcH/4QbmfHNF820=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2795c506fe8fb7b03c36ccb51f75b6df0ab2553f",
+        "rev": "c23193b943c6c689d70ee98ce3128239ed9e32d1",
         "type": "github"
       },
       "original": {

--- a/nix/t1/mill-modules.nix
+++ b/nix/t1/mill-modules.nix
@@ -122,7 +122,7 @@ let
       # Align datetime
       export SOURCE_DATE_EPOCH=1669810380
       add-determinism-q() {
-        add-determinism $@ >/dev/null
+        add-det $@ >/dev/null
       }
       add-determinism-q out/elaborator/assembly.dest/out.jar
       add-determinism-q out/omreader/assembly.dest/out.jar

--- a/script/default.nix
+++ b/script/default.nix
@@ -77,7 +77,7 @@ let
           mv out/${moduleName}/assembly.dest/out.jar $out/share/java/${moduleName}.jar
           # Align datetime
           export SOURCE_DATE_EPOCH=1669810380
-          add-determinism $out/share/java/${moduleName}.jar
+          add-det $out/share/java/${moduleName}.jar
           makeWrapper ${mill.jre}/bin/java $out/bin/${outName} \
             --add-flags "-jar $out/share/java/${moduleName}.jar"
 


### PR DESCRIPTION
* 'add-determinism' is renamed to 'add-det', see: https://github.com/keszybz/add-determinism/releases/tag/v0.7.0

The `add-determinism` package has been renamed to add-det. I’m not entirely sure about the update schedule for Nix dependencies in this project, so this PR is mainly just a gentle reminder.